### PR TITLE
Add details to coordination section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,20 +356,55 @@ testing for the specifications.
         <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
 
         <section>
-          <h3 id="w3c-coordination">W3C Groups</h3>
-          <dl>
-            <dt><a href="">Decentralized Identifier Working Group</a></dt>
-            <dd><i class="todo">[specific nature of liaison]</i></dd>
-          </dl>
+            <h3 id="w3c-coordination">W3C Groups</h3>
+            <dl>
+                <dt><a href="https://www.w3.org/RCH/WG/">RDF Canonicalization and Hashing Working Group</a></dt>
+                <dd>
+                    To synchronize on canonicalization output expression mechanisms that might be used by the Linked Data Integrity specification.
+                </dd>
 
+                <dt><a href="https://www.w3.org/2019/did-wg/">Decentralized Identifier Working Group</a></dt>
+                <dd>
+                    To synchronize on cryptography-related vocabularies and definitions.
+                </dd>
+
+                <dt><a href="https://www.w3.org/WoT/WG/">Web of Things Working Group</a></dt>
+                <dd>
+                    To synchronize on the needs and requirements of the WoT community, in particular on the subject of WoT Thing Descriptions, regarding digital signatures.
+                </dd>
+
+                <dt><a href="https://w3c-ccg.github.io/">Credentials Community Group</a></dt>
+                <dd>
+                    Coordination on other specifications incubated by the Credentials Community Group that might utilize the output of this Working Group.
+                </dd>
+
+            </dl>
         </section>
 
         <section>
-          <h3 id="external-coordination">External Organizations</h3>
-          <dl>
-            <dt><a href=""><i class="todo">[other name]</i> Working Group</a></dt>
-            <dd><i class="todo">[specific nature of liaison]</i></dd>
-          </dl>
+            <h3 id="external-coordination">External Organizations</h3>
+            <dl>
+                <dt><a href="https://datatracker.ietf.org/group/secdir/about/">Internet Engineering Task Force Security Area Directorate</a> </dt>
+                <dd>
+                    To coordinate broad horizontal reviews on the output of the Working Group among the security working groups at IETF.
+                </dd>
+                <dt><a href="https://datatracker.ietf.org/rg/cfrg/about/">Internet Engineering Task Force Crypto Forum Research Group </a> </dt>
+                <dd>
+                    To perform broad horizontal reviews on the output of the Working Group and to ensure that new pairing-based and post-quantum cryptographic algorithms and parameters can be integrated into the Linked Data Integrity ecosystem.
+                </dd>
+                <dt><a href="https://www.nist.gov/"> National Institute of Standards and Technology, U.S. Department of Commerce </a></dt>
+                <dd>
+                    To coordinate in ensuring that new pairing-based and post-quantum cryptographic algorithms and parameters can be integrated into the Linked Data Integrity ecosystem.
+                </dd>
+                <dt><a href="https://www.hyperledger.org/use/aries"> Hyperledger Aries</a></dt>
+                <dd>
+                    To coordinate on broad horizontal reviews and implementations related to the specifications developed by the Working Group.
+                </dd>
+                <dt><a href="https://identity.foundation/interop/"> Decentralized Identity Foundation Interoperability Working Group </a> </dt>
+                <dd>
+                    To coordinate on broad horizontal review and integration of the specifications developed by the Working Group into the Decentralized Identity Foundation's ecosystem.
+                </dd>
+            </dl>
         </section>
       </section>
 


### PR DESCRIPTION
This adds a number of groups that we will probably be expected to coordinate with from a "broad review" perspective.

Note, this PR presumes the `msporny-editorial` PR. Merge that PR first then retarget this one to `main`.