### PR TITLE
Add ISO and IMS as external orgs

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,6 +354,14 @@ testing for the specifications.
                 <dd>
                   To coordinate in ensuring that <a href="https://en.wikipedia.org/wiki/EIDAS">eIDAS</a>-compliant systems can be built on top of the specifications developed by the Working Group.
                 </dd>
+                <dt><a href="https://www.imsglobal.org/">IMS Global</a></dt>
+                <dd>
+                  Ensure that the badges being modeled and expressed by the Open Badges community are compatible with the Verifiable Credentials WG.
+                </dd>
+                <dt><a href="https://www.iso.org/committee/45144.html">ISO/IEC JTC 1/SC 17/WG 10</a><dt>
+                <dd>
+                  Ensure that the mobile driving licenses being modeled and expressed by the ISO SC17 WG10 community are compatible with the work of the Verifiable Credentials WG.
+                </dd>
             </dl>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -362,6 +362,10 @@ testing for the specifications.
                 <dd>
                   Ensure that the mobile driving licenses being modeled and expressed by the ISO SC17 WG10 community are compatible with the work of the Verifiable Credentials WG.
                 </dd>
+                <dt><a href="https://www.iso.org/committee/45144.html">ISO/IEC JTC 1/SC 17/WG 4</a><dt>
+                <dd>
+                  Ensure that the 23220-2 data model expressed by the ISO SC17 WG4 community is compatible with the work of the Verifiable Credentials WG.
+                </dd>
             </dl>
         </section>
       </section>


### PR DESCRIPTION
This PR adds IMS Global and ISO/IEC JTC 1/SC 17/WG 10 as External Organizations

Signed-off-by: Brent Zundel <brent.zundel@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-wg-charter/pull/26.html" title="Last updated on Dec 1, 2021, 9:26 PM UTC (6ecdebf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/26/1139c96...brentzundel:6ecdebf.html" title="Last updated on Dec 1, 2021, 9:26 PM UTC (6ecdebf)">Diff</a>