### PR TITLE
add explicit abbr definition of VC

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
         <h2>Scope</h2>
         <p>
 Building on the experience gained through implementation, deployment and usage
-of verifiable credentials, this Working Group will extend VC foundations with
+of verifiable credentials (VC), this Working Group will extend VC foundations with
 new standardized technologies to improve the use of verifiable credentials on
 the Web.
         </p>


### PR DESCRIPTION
seems `(VC)` is missing over whole draft??


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/vc-wg-charter/pull/35.html" title="Last updated on Dec 21, 2021, 3:34 AM UTC (716ccba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/35/7994a07...himorin:716ccba.html" title="Last updated on Dec 21, 2021, 3:34 AM UTC (716ccba)">Diff</a>