### PR TITLE
fixed a link to group publication status page

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@ The <b>scope</b> of the Verifiable Credentials Working Group is:
           Deliverables
         </h2>
 
-        <p>Updated document status is available on the <a href="https://www.w3.org/groups/wg/vcwg/publications">group publication status page</a>.</p>
+        <p>Updated document status is available on the <a href="https://www.w3.org/groups/wg/vc/publications">group publication status page</a>.</p>
 
         <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
 


### PR DESCRIPTION
`wg/vcwg/` -> `wg/vc/`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/vc-wg-charter/pull/36.html" title="Last updated on Dec 21, 2021, 3:43 AM UTC (461467e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/36/7994a07...himorin:461467e.html" title="Last updated on Dec 21, 2021, 3:43 AM UTC (461467e)">Diff</a>