### PR TITLE
Add concrete cryptosuites to deliverables.

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@ The <b>scope</b> of the Verifiable Credentials Working Group is:
               <p>
 This specification defines the Verifiable Credentials Data Model 2.0 along with
 serializations of that data model. It will replace the current
-<a href="https://www.w3.org/TR/vc-data-model/">VC Data Model 1.0 Recommendation</a>.
+<a href="https://www.w3.org/TR/vc-data-model/">VC Data Model 1.1 Recommendation</a>.
               </p>
 
               <p class="draft-status"><b>Draft state:</b> <a href="https://w3c.github.io/vc-data-model/">Editor's Draft</a> </p>
@@ -194,12 +194,12 @@ serializations of that data model. It will replace the current
               <dl>
                 <dt>
                   <p>
-<b>Adopted Draft:</b> <a href='https://w3c.github.io/vc-data-model/'>Verifiable Credentials Data Model 1.0</a>
+<b>Adopted Draft:</b> <a href='https://w3c.github.io/vc-data-model/'>Verifiable Credentials Data Model 1.1</a>
                   </p>
                   <p>
 <b>Exclusion Draft:</b>
-<a href='https://www.w3.org/TR/2019/REC-vc-data-model-20191119/'>Verifiable Credentials Data Model 1.0</a>
-Exclusion period <b>began</b> 25 July 2019; Exclusion period <b>ended</b> 23 September 2019.
+<a href='https://www.w3.org/TR/2021/REC-vc-data-model-20211109/'>Verifiable Credentials Data Model 1.1</a>
+Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08 January 2021.
                   </p>
                   <p>
 <b>Other Charter:</b> <a href="https://www.w3.org/2017/vc/WG/charter.html"> https://www.w3.org/2017/vc/WG/charter.html</a>
@@ -212,10 +212,24 @@ Exclusion period <b>began</b> 25 July 2019; Exclusion period <b>ended</b> 23 Sep
             <dt id="data-integrity-1" class="spec">Verifiable Credential Data Integrity 1.0</dt>
             <dd>
               <p>
-This specification defines how to express proofs of integrity, such as digital signatures or proofs of existence, for bounded documents such as verifiable credentials.
+This specification defines how to express proofs of integrity, such as digital
+signatures or proofs of existence, for bounded documents such as verifiable
+credentials. Concrete serializations will be provided for <a
+href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a> and the <a
+href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>.
+Concrete serializations might be provided for a <a
+href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a> if an <a
+href="https://identity.foundation/bbs-signature/">IETF BBS+ RFC</a> is published
+in time as well as VC-JWP if an <a
+href="https://json-web-proofs.github.io/json-web-proofs/">IETF JWP RFC</a> is
+published in time.
               </p>
 
-              <p class="draft-status"><b>Draft state:</b> <a href="https://w3c-ccg.github.io/data-integrity-spec/">Community Group Report</a> </p>
+              <p class="draft-status"><b>Draft state:</b>
+                <a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a>,
+                <a href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>,
+                <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>,
+                <a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a>
               <p class="milestone"><b>Expected completion:</b> Q4 2023</p>
             </dd>
           </dl>
@@ -262,9 +276,9 @@ The Working Group may also update Notes published under previous charters.
             <li>WG-START +1 month: First teleconference</li>
             <li>WG-START +2 months: FPWD for VCDM 2.0</li>
             <li>WG-START +5 months: First face-to-face meeting</li>
-            <li>WG-START +6 months: FPWD for VCLDI 1.0</li>
+            <li>WG-START +6 months: FPWD for VCDI 1.0</li>
             <li>WG-START +14 months: CR for VCDM 2.0</li>
-            <li>WG-START +18 months: CR for VCLDI 1.0</li>
+            <li>WG-START +18 months: CR for VCDI 1.0</li>
             <li>WG-START +24 months: REC for all standards-track documents</li>
           </ul>
         </section>

--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@ serializations of that data model. It will replace the current
 Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08 January 2022.
                   </p>
                   <p>
-<b>Other Charter:</b> <a href="https://www.w3.org/2017/vc/WG/charter.html"> https://www.w3.org/2017/vc/WG/charter.html</a>
+<b>Other Charter:</b> <a href="https://www.w3.org/2020/12/verifiable-credentials-wg-charter.html"> https://www.w3.org/2020/12/verifiable-credentials-wg-charter.html</a>
                   </p>
                 </dd>
               </dl>

--- a/index.html
+++ b/index.html
@@ -214,10 +214,10 @@ Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08
               <p>
 This specification defines how to express proofs of integrity, such as digital
 signatures or proofs of existence, for bounded documents, such as verifiable
-credentials. Concrete serializations will be provided for <a
+credentials. Concrete serializations will be provided based on <a
 href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a> and the <a
 href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>.
-Concrete serializations might be provided for a <a
+Concrete serializations might be provided based on the <a
 href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a>, if an <a
 href="https://identity.foundation/bbs-signature/">IETF BBS+ RFC</a> is published
 in time, as well as VC-JWP, if an <a

--- a/index.html
+++ b/index.html
@@ -215,25 +215,29 @@ Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08
 This specification defines how to express proofs of integrity, such as digital
 signatures or proofs of existence, for bounded documents, such as verifiable
 credentials. Concrete serializations will be provided based on <a
-href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a> and the <a
-href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>.
-Concrete serializations might be provided based on the <a
+href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>, the <a
+href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>, and
+the <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1
+Cryptosuite</a>. Concrete serializations might be provided based on the <a
 href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a>, if an <a
 href="https://identity.foundation/bbs-signature/">IETF BBS+ RFC</a> is published
-in time, as well as VC-JWP, if an <a
+in time. Concrete serializations might be provided for VC-JWP, if an <a
 href="https://json-web-proofs.github.io/json-web-proofs/">IETF JWP RFC</a> is
-published in time.
+published in time. The final output specifications might not map directly to
+the list of input drafts. Other output serializations covering cryptographic
+primitives published in IETF RFCs not mentioned in this paragraph might be
+produced.
               </p>
 
               <p class="draft-status"><b>Draft state:</b>
                 <a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a>,
                 <a href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>,
                 <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>,
+                <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1 Cryptosuite</a>,
                 <a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a>
               <p class="milestone"><b>Expected completion:</b> Q4 2023</p>
             </dd>
           </dl>
-
 
         </section>
 

--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@ serializations of that data model. It will replace the current
                   <p>
 <b>Exclusion Draft:</b>
 <a href='https://www.w3.org/TR/2021/REC-vc-data-model-20211109/'>Verifiable Credentials Data Model 1.1</a>
-Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08 January 2021.
+Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08 January 2022.
                   </p>
                   <p>
 <b>Other Charter:</b> <a href="https://www.w3.org/2017/vc/WG/charter.html"> https://www.w3.org/2017/vc/WG/charter.html</a>
@@ -213,14 +213,14 @@ Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08
             <dd>
               <p>
 This specification defines how to express proofs of integrity, such as digital
-signatures or proofs of existence, for bounded documents such as verifiable
+signatures or proofs of existence, for bounded documents, such as verifiable
 credentials. Concrete serializations will be provided for <a
 href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a> and the <a
 href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>.
 Concrete serializations might be provided for a <a
-href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a> if an <a
+href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a>, if an <a
 href="https://identity.foundation/bbs-signature/">IETF BBS+ RFC</a> is published
-in time as well as VC-JWP if an <a
+in time, as well as VC-JWP, if an <a
 href="https://json-web-proofs.github.io/json-web-proofs/">IETF JWP RFC</a> is
 published in time.
               </p>


### PR DESCRIPTION
This PR implements a VCWG request from the 2021-12-15 telecon -- the request was to make it clear that the group intends to deliver concrete serializations of data integrity proofs (we are not just doing a meta data model). It was also requested to make it clear which cryptosuites and data integrity mechanisms were in scope for normative deliverables.

The JWP one is a bit out on a limb given that we don't have any implementations or a spec that goes along w/ the VC Data Model spec... but some felt it might be good to include it as an optional normative deliverable if the IETF RFCs materialize in time. We have working implementations, specs, and initial test suites for all the other normative deliverables.

This PR also updates the VC 1.0 spec references to VC 1.1 since that will be a reality by the time people get around to really analyzing this charter.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/pull/37.html" title="Last updated on Jan 13, 2022, 8:40 PM UTC (409f068)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/37/264504c...409f068.html" title="Last updated on Jan 13, 2022, 8:40 PM UTC (409f068)">Diff</a>