### PR TITLE
to allow for multibase support in the VCDI spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,7 +223,8 @@ href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>, and
 the <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1
 Cryptosuite</a>. Concrete serializations based on the <a 
 href=https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-04>Multibase
- Data Format</a> might be provided. Concrete serializations based on the <a
+Data Format</a> and the <a href=https://ns.did.ai/suites/multikey-2021/v1/>Multikey-2021
+suite</a> might be provided. Concrete serializations based on the <a
 href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a> might be provided, if an <a
 href="https://identity.foundation/bbs-signature/">IETF BBS+ RFC</a> is published
 in time. Concrete serializations for VC-JWP might be provided, if an <a
@@ -240,8 +241,7 @@ produced.
                 <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>,
                 <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1 Cryptosuite</a>,
                 <a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a>,
-                <a href=https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-04>Multibase
- Data Format</a>
+                <a href="https://ns.did.ai/suites/multikey-2021/">Multikey-2021</a>
                 </p>
               <p class="milestone"><b>Expected completion:</b> Q4 2023</p>
             </dd>

--- a/index.html
+++ b/index.html
@@ -232,7 +232,8 @@ the <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1
 Cryptosuite</a>. Concrete serializations based on the <a 
 href=https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-04>Multibase
 Data Format</a> and the <a href=https://ns.did.ai/suites/multikey-2021/v1/>Multikey-2021
-suite</a> might be provided. Concrete serializations based on the <a
+suite</a> might be provided if the latter is specified and published in time. Concrete
+ serializations based on the <a
 href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a> might be provided, if an <a
 href="https://identity.foundation/bbs-signature/">IETF BBS+ RFC</a> is published
 in time. Concrete serializations for VC-JWP might be provided, if an <a

--- a/index.html
+++ b/index.html
@@ -221,7 +221,9 @@ credentials. Concrete serializations will be provided based on <a
 href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>, the <a
 href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>, and
 the <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1
-Cryptosuite</a>. Concrete serializations based on the <a
+Cryptosuite</a>. Concrete serializations based on the <a 
+href=https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-04>Multibase
+ Data Format</a> might be provided. Concrete serializations based on the <a
 href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a> might be provided, if an <a
 href="https://identity.foundation/bbs-signature/">IETF BBS+ RFC</a> is published
 in time. Concrete serializations for VC-JWP might be provided, if an <a
@@ -237,7 +239,10 @@ produced.
                 <a href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>,
                 <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>,
                 <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1 Cryptosuite</a>,
-                <a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a>
+                <a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a>,
+                <a href=https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-04>Multibase
+ Data Format</a>
+                </p>
               <p class="milestone"><b>Expected completion:</b> Q4 2023</p>
             </dd>
           </dl>


### PR DESCRIPTION
As discussed in #46, Spruce would support proofs signed by keys represented in multibase format being in scope for the VCDI deliverable.  Spruce uses `did:key` (links [here](https://github.com/w3c/vc-wg-charter/issues/46#issuecomment-1022678597)) already and is interested in signing and verifying bounded documents with key materials represented in multibase format in other use-cases as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bumblefudge/vc-wg-charter/pull/51.html" title="Last updated on Feb 1, 2022, 11:39 PM UTC (4393a47)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/51/15e8d9e...bumblefudge:4393a47.html" title="Last updated on Feb 1, 2022, 11:39 PM UTC (4393a47)">Diff</a>