### PR TITLE
Add ECDSA secpr1 cryptosuite to VCWG input documents.

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,8 +219,10 @@ This specification defines how to express proofs of integrity, such as digital
 signatures or proofs of existence, for bounded documents, such as verifiable
 credentials. Concrete serializations will be provided based on <a
 href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>, the <a
-href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>, and
-the <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1
+href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>,
+the <a href="https://digitalbazaar.github.io/di-ecdsa-secpr1-2019/">Secpr1
+Cryptosuite</a>, and the
+<a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1
 Cryptosuite</a>. Concrete serializations based on the <a
 href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a> might be provided, if an <a
 href="https://identity.foundation/bbs-signature/">IETF BBS+ RFC</a> is published
@@ -236,6 +238,7 @@ produced.
                 <a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a>,
                 <a href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>,
                 <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>,
+                <a href="https://digitalbazaar.github.io/di-ecdsa-secpr1-2019/">Secpr1 Cryptosuite</a>,
                 <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1 Cryptosuite</a>,
                 <a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a>
               <p class="milestone"><b>Expected completion:</b> Q4 2023</p>

--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@ produced.
                 <a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a>,
                 <a href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>,
                 <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>,
-                <a href="https://digitalbazaar.github.io/di-ecdsa-secpr1-2019/">Secpr1 Cryptosuite</a>,
+                <a href="https://w3c-ccg.github.io/di-ecdsa-secpr1-2019/">Secpr1 Cryptosuite</a>,
                 <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1 Cryptosuite</a>,
                 <a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a>
               <p class="milestone"><b>Expected completion:</b> Q4 2023</p>

--- a/index.html
+++ b/index.html
@@ -220,7 +220,7 @@ signatures or proofs of existence, for bounded documents, such as verifiable
 credentials. Concrete serializations will be provided based on <a
 href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>, the <a
 href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>,
-the <a href="https://digitalbazaar.github.io/di-ecdsa-secpr1-2019/">Secpr1
+the <a href="https://w3c-ccg.github.io/di-ecdsa-secpr1-2019/">Secpr1
 Cryptosuite</a>, and the
 <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1
 Cryptosuite</a>. Concrete serializations based on the <a


### PR DESCRIPTION
This PR adds the ECDSA secpr1 cryptosuite to the set of VCWG input documents. The work item is currently being processed for adoption by the CCG:

https://github.com/w3c-ccg/community/issues/228

The PR is meant to be a placeholder until its adoption in CCG (and then the URLs to the spec will be updated).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/pull/63.html" title="Last updated on Feb 15, 2022, 8:15 PM UTC (1c406dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/63/9a2a8d1...1c406dc.html" title="Last updated on Feb 15, 2022, 8:15 PM UTC (1c406dc)">Diff</a>