### PR TITLE
Add ACLU as liaison.

### DIFF
--- a/index.html
+++ b/index.html
@@ -376,6 +376,10 @@ testing for the specifications.
                 <dd>
                     To coordinate on broad horizontal reviews and implementations related to the specifications developed by the Working Group.
                 </dd>
+                <dt><a href="https://www.aclu.org/">The American Civil Liberties Union</a> </dt>
+                <dd>
+                    To coordinate on ensuring that the deliverables of the Working Group are a net positive for civil liberties.
+                </dd>
                 <dt><a href="https://identity.foundation/interop/"> Decentralized Identity Foundation Interoperability Working Group </a> </dt>
                 <dd>
                     To coordinate on broad horizontal review and integration of the specifications developed by the Working Group into the Decentralized Identity Foundation's ecosystem.


### PR DESCRIPTION
Some of us have been speaking with the ACLU about VCs and their potential over the last year. This PR furthers that relationship and establishes a more formal one between the ACLU and the VCWG. 

The goal here is to enable the ACLU to provide input and guidance to the VCWG from a civil liberties perspective.

Doing this would be a wise step for the VCWG because of the concerns that they have raised with the way that mDL is expected to be deployed and the very public way those concerns came to light. While VCWG has more options from a privacy preservation perspective than mDL does, it is imperative that the group get more regular feedback on how we're doing as we refine the Verifiable Credentials technology.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/pull/69.html" title="Last updated on Feb 4, 2022, 12:25 AM UTC (7d08287)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/69/9a2a8d1...7d08287.html" title="Last updated on Feb 4, 2022, 12:25 AM UTC (7d08287)">Diff</a>