### PR TITLE
Normative specification of APIs or protocols is out of scope

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,7 @@ The <b>scope</b> of the Verifiable Credentials Working Group is:
             <ul class="out-of-scope">
               <li>The mandate of any specific style of supporting infrastructure (such as a DLT) for a verifiable credentials ecosystem</li>
               <li>The specification of new cryptographic primitives</li>
+              <li>The normative specification of APIs or protocols</li>
             </ul>
         </section>
 


### PR DESCRIPTION
I believe that we have consensus that normative specification of APIs or protocols is out of scope.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/vc-wg-charter/pull/70.html" title="Last updated on Feb 9, 2022, 3:42 AM UTC (07f47e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/70/b8871ea...selfissued:07f47e8.html" title="Last updated on Feb 9, 2022, 3:42 AM UTC (07f47e8)">Diff</a>