### PR TITLE
Refactor WG inputs and outputs to follow (approved) WebApps Charter style

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,8 +243,8 @@ determined by the Working Group. The following are a non-exhaustive selection
 of expected input documents:
               </p>
               <p class="input-documents"><b>Container Formats:</b>
-                <a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a>,
-                <a href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>
+                <a href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>,
+                <a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a>
               </p>
               <p class="input-documents"><b>Cryptosuites:</b>
                 <a href="https://github.com/w3c-ccg/lds-jws2020/">JSON Web Signature</a>,

--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@ Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08
             <dt id="data-integrity-1" class="spec">Verifiable Credential Data Integrity 1.0</dt>
             <dd>
               <p>
-This family of specifications defines how to express proofs of integrity for
+This family of specifications consists of specifications that each define how to express proofs of integrity for
 verifiable credentials using a number of concrete serializations for each of the
 defined syntaxes. The specific set of concrete serializations included will be
 determined by the Working Group. The following are a non-exhaustive selection

--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@ determined by the Working Group.
                 <a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a>,
                 <a href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>,
                 <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>,
-                <a href="https://json-web-proofs.github.io/json-web-proofs/">IETF JWP RFC</a>
+                <a href="https://w3c-ccg.github.io/di-ecdsa-secpr1-2019/">Secpr1 Cryptosuite</a>,
                 <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1 Cryptosuite</a>,
                 <a href="https://github.com/w3c-ccg/lds-jws2020/">JSON Web Signature 2020</a>
               <p class="milestone"><b>Expected completion:</b> <span class=todo>WG-START+24 months</span></p>

--- a/index.html
+++ b/index.html
@@ -236,11 +236,11 @@ Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08
             <dt id="data-integrity-1" class="spec">Verifiable Credential Data Integrity 1.0</dt>
             <dd>
               <p>
-This family of specifications consists of specifications that each define how to express proofs of integrity for
-verifiable credentials using a number of concrete serializations for each of the
-defined syntaxes. The specific set of concrete serializations included will be
-determined by the Working Group. The following are a non-exhaustive selection
-of expected input documents:
+This family of specifications consists of documents that each define how to
+express proofs of integrity for verifiable credentials using a number of
+concrete serializations for each of the defined syntaxes. The specific set of
+concrete serializations included will be determined by the Working Group. The
+following are a non-exhaustive selection of expected input documents:
               </p>
               <p class="input-documents"><b>Container Formats:</b>
                 <a href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>,

--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@ following are a non-exhaustive selection of expected input documents:
                 <a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a>
               </p>
               <p class="input-documents"><b>Cryptosuites:</b>
-                <a href="https://github.com/w3c-ccg/lds-jws2020/">JSON Web Signature</a>,
+                <a href="https://github.com/w3c-ccg/lds-jws2020/">JSON Web Signature 2020</a>,
                 <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">EdDSA</a>,
                 <a href="https://w3c-ccg.github.io/di-ecdsa-secpr1-2019/">NIST ECDSA</a>,
                 <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Koblitz ECDSA</a>

--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@ following are a non-exhaustive selection of expected input documents:
 Depending on progress in the
 <a href="https://www.w3.org/community/credentials/">W3C Credentials Community Group</a>
 and the <a href="https://www.ietf.org/">IETF</a>, the Working Group may also
-produce W3C Recommendations for the following documents:
+produce W3C Recommendations based on the following documents:
           </p>
 
           <table>

--- a/index.html
+++ b/index.html
@@ -236,9 +236,9 @@ Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08
             <dt id="data-integrity-1" class="spec">Verifiable Credential Data Integrity 1.0</dt>
             <dd>
               <p>
-This specification defines how to express proofs of integrity for verifiable
-credentials using a number of concrete serializations for each of the defined
-syntaxes. The specific set of concrete serializations included will be
+This family of specifications defines how to express proofs of integrity for
+verifiable credentials using a number of concrete serializations for each of the
+defined syntaxes. The specific set of concrete serializations included will be
 determined by the Working Group.
               </p>
               <p class="draft-status"><b>Draft state:</b> No Draft </p>
@@ -274,7 +274,7 @@ produce W3C Recommendations for the following documents:
             </tr>
             <tr>
               <td>
-<a href="https://or13.github.io/lds-pgp2021/">PGP Cryptosuite</a>
+<a href="https://or13.github.io/lds-pgp2021/">PGP&nbsp;Cryptosuite</a>
               </td>
               <td>
 A cryptographic digital signature suite that utilizes Pretty Good Privacy [<a
@@ -283,7 +283,7 @@ href="https://datatracker.ietf.org/doc/html/rfc4880">RFC4880</a>].
             </tr>
             <tr>
               <td>
-<a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a>
+<a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+&nbsp;Cryptosuite</a>
               </td>
               <td>
 A cryptographic digital signature suite supporting selective disclosure.

--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@ of expected input documents:
 
         <section id="normative">
           <h3>
-            CCG and IETF Specifications
+            Conditional Normative Specifications
           </h3>
           <p>
 Depending on progress in the

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@ seeking to better understand some the terminology used in this charter e.g., cre
             <td>
               See the <a href="https://www.w3.org/groups/wg/vc/charters">group status page</a> and <a href="#history">detailed change history</a>.</i>
             </td>
-          </tr>	
+          </tr>
           <tr id="Duration">
             <th>
               Start date
@@ -242,7 +242,6 @@ syntaxes. The specific set of concrete serializations included will be
 determined by the Working Group.
               </p>
               <p class="draft-status"><b>Draft state:</b> No Draft </p>
-
               <p class="input-documents"><b>Input documents:</b></p>
                 <p>(the following are a non-exhaustive selection of expected input documents)</p>
                 <a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a>,
@@ -250,12 +249,54 @@ determined by the Working Group.
                 <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>,
                 <a href="https://json-web-proofs.github.io/json-web-proofs/">IETF JWP RFC</a>
                 <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1 Cryptosuite</a>,
-                <a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a>,
-                <a href="https://github.com/w3c-ccg/lds-jws2020/">JSON Web Signature 2020</a>              
+                <a href="https://github.com/w3c-ccg/lds-jws2020/">JSON Web Signature 2020</a>
               <p class="milestone"><b>Expected completion:</b> <span class=todo>WG-START+24 months</span></p>
             </dd>
           </dl>
 
+        </section>
+
+        <section id="normative">
+          <h3>
+            CCG and IETF Specifications
+          </h3>
+          <p>
+Depending on progress in the
+<a href="https://www.w3.org/community/credentials/">W3C Credentials Community Group</a>
+and the <a href="https://www.ietf.org/">IETF</a>, the Working Group may also
+produce W3C Recommendations for the following documents:
+          </p>
+
+          <table>
+            <tr>
+              <th>Specification</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>
+<a href="https://or13.github.io/lds-pgp2021/">PGP Cryptosuite</a>
+              </td>
+              <td>
+A cryptographic digital signature suite that utilizes Pretty Good Privacy [<a
+href="https://datatracker.ietf.org/doc/html/rfc4880">RFC4880</a>].
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+ Cryptosuite</a>
+              </td>
+              <td>
+A cryptographic digital signature suite supporting selective disclosure.
+              </td>
+            </tr>
+            <tr>
+              <td><a href="https://json-web-proofs.github.io/json-web-proofs/">VC-JWP</a></td>
+              <td>
+A data model for expressing JWT-like proofs for selective disclosure and other
+modern cryptographic schemes.
+              </td>
+            </tr>
+          </table>
         </section>
 
         <section id="ig-other-deliverables">
@@ -319,8 +360,8 @@ listed here.
         <h2>Success Criteria</h2>
 
         <p>
-          In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, 
-          each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at 
+          In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>,
+          each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at
           least two independent implementations</a> of every feature defined in the specification.
         </p>
 
@@ -536,7 +577,7 @@ listed here.
 
           <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 4.3, Advisory Committee Review of a Charter)</a>:</p>
 
- 
+
           <table class="history">
             <tbody>
               <tr>

--- a/index.html
+++ b/index.html
@@ -294,8 +294,8 @@ A cryptographic digital signature suite supporting selective disclosure.
             <tr>
               <td><a href="https://json-web-proofs.github.io/json-web-proofs/">VC-JWP</a></td>
               <td>
-A data model for expressing JWT-like proofs for selective disclosure and other
-modern cryptographic schemes.
+A cryptographic container format for expressing JWT-like proofs for selective
+disclosure and other modern cryptographic schemes.
               </td>
             </tr>
           </table>

--- a/index.html
+++ b/index.html
@@ -239,17 +239,19 @@ Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08
 This family of specifications defines how to express proofs of integrity for
 verifiable credentials using a number of concrete serializations for each of the
 defined syntaxes. The specific set of concrete serializations included will be
-determined by the Working Group.
+determined by the Working Group. The following are a non-exhaustive selection
+of expected input documents:
               </p>
-              <p class="draft-status"><b>Draft state:</b> No Draft </p>
-              <p class="input-documents"><b>Input documents:</b></p>
-                <p>(the following are a non-exhaustive selection of expected input documents)</p>
+              <p class="input-documents"><b>Container Formats:</b>
                 <a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a>,
-                <a href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>,
-                <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Cryptosuite</a>,
-                <a href="https://w3c-ccg.github.io/di-ecdsa-secpr1-2019/">Secpr1 Cryptosuite</a>,
-                <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Secp256k1 Cryptosuite</a>,
-                <a href="https://github.com/w3c-ccg/lds-jws2020/">JSON Web Signature 2020</a>
+                <a href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JWT</a>
+              </p>
+              <p class="input-documents"><b>Cryptosuites:</b>
+                <a href="https://github.com/w3c-ccg/lds-jws2020/">JSON Web Signature</a>,
+                <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">EdDSA</a>,
+                <a href="https://w3c-ccg.github.io/di-ecdsa-secpr1-2019/">NIST ECDSA</a>,
+                <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Koblitz ECDSA</a>
+              </p>
               <p class="milestone"><b>Expected completion:</b> <span class=todo>WG-START+24 months</span></p>
             </dd>
           </dl>


### PR DESCRIPTION
This PR builds on PR #76, #73, #66, #63, #51, and #50 and refactors them in a way that other WGs have found success wrt. charter approval. It also addresses @Sakurann's request to categorize the layering, and @selfissued's request to put the JWP work back in scope (if adequate progress has been made at IETF).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/pull/77.html" title="Last updated on Mar 2, 2022, 3:32 PM UTC (bc62887)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/77/17404f4...bc62887.html" title="Last updated on Mar 2, 2022, 3:32 PM UTC (bc62887)">Diff</a>