### PR TITLE
Add Deliverables section on Registries

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,8 +306,11 @@ disclosure and other modern cryptographic schemes.
             Registries
           </h3>
           <p>
-A series of at least the following registries that support the normative
-deliverables of the Working Group will be published and maintained:
+The Working Group will deliver a set of registries on the [W3C Registry
+Track](https://www.w3.org/2021/Process-20211102/#registries) to
+support extension points in the above normative deliverables. The
+Working Group expects to produce the following registries, but it will
+adjust this list as needed to support the normative deliverables:
           </p>
           <table>
             <tr>

--- a/index.html
+++ b/index.html
@@ -306,8 +306,7 @@ disclosure and other modern cryptographic schemes.
             Registries
           </h3>
           <p>
-The Working Group will deliver a set of registries on the [W3C Registry
-Track](https://www.w3.org/2021/Process-20211102/#registries) to
+The Working Group will deliver a set of registries on the <a href="https://www.w3.org/2021/Process-20211102/#registries">W3C Registry Track</a> to
 support extension points in the above normative deliverables. The
 Working Group expects to produce the following registries, but it will
 adjust this list as needed to support the normative deliverables:

--- a/index.html
+++ b/index.html
@@ -306,10 +306,11 @@ disclosure and other modern cryptographic schemes.
             Registries
           </h3>
           <p>
-The Working Group will deliver a set of registries on the <a href="https://www.w3.org/2021/Process-20211102/#registries">W3C Registry Track</a> to
-support extension points in the above normative deliverables. The
-Working Group expects to produce the following registries, but it will
-adjust this list as needed to support the normative deliverables:
+The Working Group may deliver a set of registries on the
+<a href="https://www.w3.org/2021/Process-20211102/#registries">W3C Registry Track</a>
+to support extension points in the above normative deliverables. The Working
+Group might produce the following registries and will adjust this list
+as needed to support the normative deliverables:
           </p>
           <table>
             <tr>

--- a/index.html
+++ b/index.html
@@ -320,10 +320,11 @@ adjust this list as needed to support the normative deliverables:
             </tr>
             <tr>
               <td>
-Verifiable Credential Extensions Registry
+Verifiable Credential Properties Registry
               </td>
               <td>
-A registry of extensions to the Verifiable Credentials Data Model specification.
+A registry of extensions to properties used in the Verifiable Credentials Data
+Model specification.
               </td>
               <td>
 <a href="https://w3c-ccg.github.io/vc-extension-registry/">Verifiable Credential Extensions Registry</a>
@@ -335,7 +336,7 @@ Cryptographic Container and Suite Registry
               </td>
               <td>
 A registry of cryptographic container formats and cryptographic suites that
-are useful in conjunction with specifications managed by this Working Group
+are useful in conjunction with specifications managed by this Working Group.
               </td>
               <td>
 <a href="https://w3c-ccg.github.io/security-vocab/#classes">Classes in CCG Security Vocabulary</a>

--- a/index.html
+++ b/index.html
@@ -339,7 +339,7 @@ A registry of cryptographic container formats and cryptographic suites that
 are useful in conjunction with specifications managed by this Working Group.
               </td>
               <td>
-<a href="https://w3c-ccg.github.io/security-vocab/#classes">Classes in CCG Security Vocabulary</a>
+<a href="https://w3c-ccg.github.io/security-vocab/#classes">Classes in Security Vocabulary</a>
               </td>
             </tr>
             <tr>

--- a/index.html
+++ b/index.html
@@ -316,38 +316,51 @@ adjust this list as needed to support the normative deliverables:
             <tr>
               <th>Registry</th>
               <th>Description</th>
+              <th>Based on</th>
             </tr>
             <tr>
               <td>
-<a href="https://w3c-ccg.github.io/vc-extension-registry/">Verifiable Credential Extensions Registry</a>
+Verifiable Credential Extensions Registry
               </td>
               <td>
 A registry of extensions to the Verifiable Credentials Data Model specification.
               </td>
+              <td>
+<a href="https://w3c-ccg.github.io/vc-extension-registry/">Verifiable Credential Extensions Registry</a>
+              </td>
             </tr>
             <tr>
               <td>
-<a href="https://w3c-ccg.github.io/security-vocab/#classes">Cryptographic Container and Suite Registry</a>
+Cryptographic Container and Suite Registry
               </td>
               <td>
 A registry of cryptographic container formats and cryptographic suites that
 are useful in conjunction with specifications managed by this Working Group
               </td>
+              <td>
+<a href="https://w3c-ccg.github.io/security-vocab/#classes">Classes in CCG Security Vocabulary</a>
+              </td>
             </tr>
             <tr>
               <td>
-<a href="https://w3c.github.io/did-spec-registries/#verification-method-types">Verification Method Registry</a>
+Verification Method Registry
               </td>
               <td>
 A registry of <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-verification-method">verification methods</a>.
               </td>
+              <td>
+<a href="https://w3c.github.io/did-spec-registries/#verification-method-types">Verification Methods in DID Registry</a>
+              </td>
             </tr>
             <tr>
               <td>
-<a href="https://w3c.github.io/did-spec-registries/#verification-relationships">Verification Relationship Registry</a>
+Verification Relationship Registry
               </td>
               <td>
 A registry of <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-verification-relationship">verification relationships</a>.
+              </td>
+              <td>
+<a href="https://w3c.github.io/did-spec-registries/#verification-relationships">Verification Relationships in DID Registry</a>
               </td>
             </tr>
           </table>

--- a/index.html
+++ b/index.html
@@ -301,6 +301,55 @@ disclosure and other modern cryptographic schemes.
           </table>
         </section>
 
+        <section id="normative">
+          <h3>
+            Registries
+          </h3>
+          <p>
+A series of at least the following registries that support the normative
+deliverables of the Working Group will be published and maintained:
+          </p>
+          <table>
+            <tr>
+              <th>Registry</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>
+<a href="https://w3c-ccg.github.io/vc-extension-registry/">Verifiable Credential Extensions Registry</a>
+              </td>
+              <td>
+A registry of extensions to the Verifiable Credentials Data Model specification.
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a href="https://w3c-ccg.github.io/security-vocab/#classes">Cryptographic Container and Suite Registry</a>
+              </td>
+              <td>
+A registry of cryptographic container formats and cryptographic suites that
+are useful in conjunction with specifications managed by this Working Group
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a href="https://w3c.github.io/did-spec-registries/#verification-method-types">Verification Method Registry</a>
+              </td>
+              <td>
+A registry of <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-verification-method">verification methods</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a href="https://w3c.github.io/did-spec-registries/#verification-relationships">Verification Relationship Registry</a>
+              </td>
+              <td>
+A registry of <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-verification-relationship">verification relationships</a>.
+              </td>
+            </tr>
+          </table>
+        </section>
+
         <section id="ig-other-deliverables">
           <h3>
             Other Deliverables


### PR DESCRIPTION
Given that the Verifiable Credentials Data Model and Data Integrity specifications contain various extension points, this PR adds a Deliverables section on Registries that the group knows it will have to create (at a minimum).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/pull/85.html" title="Last updated on Mar 4, 2022, 10:38 PM UTC (0cdfcbb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/85/bb419e2...0cdfcbb.html" title="Last updated on Mar 4, 2022, 10:38 PM UTC (0cdfcbb)">Diff</a>