### PR TITLE
Complete the list of known cryptosuites of interest for standardization.

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,6 +299,10 @@ disclosure and other modern cryptographic schemes.
               </td>
             </tr>
           </table>
+          <p>
+Other cryptographic suites for NIST RSA, EASC DSA, or SM9 IBSA may be produced
+under the same conditions as the table above.
+          </p>
         </section>
 
         <section id="ig-other-deliverables">

--- a/index.html
+++ b/index.html
@@ -300,8 +300,11 @@ disclosure and other modern cryptographic schemes.
             </tr>
           </table>
           <p>
-Other cryptographic suites for NIST RSA, EASC DSA, or SM9 IBSA may be produced
-under the same conditions as the table above.
+Other cryptographic suites for
+<a href="https://datatracker.ietf.org/doc/html/rfc8017">NIST RSA</a>,
+<a href="https://datatracker.ietf.org/doc/html/rfc4490">EASC DSA</a>, or
+<a href="https://standards.ieee.org/ieee/1363.3/3822/">SM9 IBSA</a> may be
+produced under the same conditions as the table above.
           </p>
         </section>
 


### PR DESCRIPTION
This PR adds the missing cryptosuites that were outlined here as a response to @Sakurann, but don't have input documents: https://github.com/w3c/vc-wg-charter/pull/76#discussion_r808358109

We could integrate them into the table above, or we could leave them as a footnote (which this PR does).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/pull/93.html" title="Last updated on Mar 2, 2022, 7:05 PM UTC (1c9e6f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/93/bb419e2...1c9e6f7.html" title="Last updated on Mar 2, 2022, 7:05 PM UTC (1c9e6f7)">Diff</a>