### PR TITLE
Add conditional normative deliverables for post-quantum crypto and other externally standardized primitives

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,9 +302,10 @@ disclosure and other modern cryptographic schemes.
           <p>
 Other cryptographic suites for
 <a href="https://datatracker.ietf.org/doc/html/rfc8017">NIST RSA</a>,
-<a href="https://datatracker.ietf.org/doc/html/rfc4490">EASC DSA</a>, or
-<a href="https://standards.ieee.org/ieee/1363.3/3822/">SM9 IBSA</a> may be
-produced under the same conditions as the table above.
+<a href="https://datatracker.ietf.org/doc/html/rfc4490">EASC DSA</a>,
+<a href="https://standards.ieee.org/ieee/1363.3/3822/">SM9 IBSA</a>, or
+<a href="https://csrc.nist.gov/Projects/post-quantum-cryptography">NIST post-quantum cryptography</a>
+may be produced under the same conditions as the table above.
           </p>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -303,9 +303,10 @@ disclosure and other modern cryptographic schemes.
 Other cryptographic suites for
 <a href="https://datatracker.ietf.org/doc/html/rfc8017">NIST RSA</a>,
 <a href="https://datatracker.ietf.org/doc/html/rfc4490">EASC DSA</a>,
-<a href="https://standards.ieee.org/ieee/1363.3/3822/">SM9 IBSA</a>, or
-<a href="https://csrc.nist.gov/Projects/post-quantum-cryptography">NIST post-quantum cryptography</a>
-may be produced under the same conditions as the table above.
+<a href="https://standards.ieee.org/ieee/1363.3/3822/">SM9 IBSA</a>,
+<a href="https://csrc.nist.gov/Projects/post-quantum-cryptography">NIST post-quantum cryptography</a>,
+or other externally standardized cryptographic primitives may be produced under
+the same conditions as the table above.
           </p>
         </section>
 


### PR DESCRIPTION
This PR mentions potential conditional normative deliverables for post-quantum crypto and other externally standardized primitives. The presumption is that the proper cryptographic work has been performed and selected by NIST and/or has been standardized by IETF or other groups containing the appropriate cryptographic experts that standardize cryptographic primitives.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/pull/95.html" title="Last updated on Mar 4, 2022, 5:22 PM UTC (bf8e0c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/95/7564db1...bf8e0c3.html" title="Last updated on Mar 4, 2022, 5:22 PM UTC (bf8e0c3)">Diff</a>