### PR TITLE
Clarify that DI should focus on VCs but ensure generality.

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@ Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08
             <dd>
               <p>
 This family of specifications consists of documents that each define how to
-express proofs of integrity for verifiable credentials using a number of
+associate proofs of integrity with data, focusing on verifiable credentials and
 concrete serializations for each of the defined syntaxes. The specific set of
 concrete serializations included will be determined by the Working Group. The
 following are a non-exhaustive selection of expected input documents:

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@ Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08
             <dd>
               <p>
 This family of specifications consists of documents that each define how to
-associate proofs of integrity with data, focusing on verifiable credentials and
+express and associate proofs of integrity with data, focusing on verifiable credentials and
 concrete serializations for each of the defined syntaxes. The specific set of
 concrete serializations included will be determined by the Working Group. The
 following are a non-exhaustive selection of expected input documents:

--- a/index.html
+++ b/index.html
@@ -237,8 +237,10 @@ Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08
             <dd>
               <p>
 This family of specifications consists of documents that each define how to
-express and associate proofs of integrity with data, focusing on verifiable credentials and
-concrete serializations for each of the defined syntaxes. The specific set of
+express and associate proofs of integrity for verifiable credentials and
+concrete serializations for each of the defined syntaxes. The Working Group
+would welcome the usage of these techniques for data in general, but
+its scope will be to solve verifiable credentials use cases. The specific set of
 concrete serializations included will be determined by the Working Group. The
 following are a non-exhaustive selection of expected input documents:
               </p>


### PR DESCRIPTION
This PR attempts to ensure that the group doesn't lose sight of the fact that the "proofs of integrity" utilize generalized solutions (JWTs, JWPs, DI). That is, in general, we shouldn't take a generalized solution and make it so specialized to VCs that you can only ever use the solution with VCs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/pull/96.html" title="Last updated on Mar 22, 2022, 2:38 PM UTC (f335c8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/96/53f1da0...f335c8e.html" title="Last updated on Mar 22, 2022, 2:38 PM UTC (f335c8e)">Diff</a>