### PR TITLE
Registries and standardized entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,7 +310,9 @@ The Working Group may create a set of
 <a href="https://www.w3.org/2021/Process-20211102/#registries">registries</a>
 including <a href="https://www.w3.org/2021/Process-20211102/#registry-definition">registry definitions</a>
 and <a href="https://www.w3.org/2021/Process-20211102/#registry-table">registry tables</a>
-to support extension points in the above normative deliverables.
+to support extension points in the above normative deliverables. Registries for
+extension points that are required by any of the above normative deliverables
+must have at least one standardized entry.
           </p>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -306,8 +306,11 @@ disclosure and other modern cryptographic schemes.
             Registries
           </h3>
           <p>
-A series of at least the following registries that support the normative
-deliverables of the Working Group will be published and maintained:
+The Working Group will deliver a set of registries on the [W3C Registry
+Track](https://www.w3.org/2021/Process-20211102/#registries) to
+support extension points in the above normative deliverables. The
+Working Group expects to produce the following registries, but it will
+adjust this list as needed to support the normative deliverables:
           </p>
           <table>
             <tr>

--- a/index.html
+++ b/index.html
@@ -306,8 +306,7 @@ disclosure and other modern cryptographic schemes.
             Registries
           </h3>
           <p>
-The Working Group will deliver a set of registries on the [W3C Registry
-Track](https://www.w3.org/2021/Process-20211102/#registries) to
+The Working Group will deliver a set of registries on the <a href="https://www.w3.org/2021/Process-20211102/#registries">W3C Registry Track</a> to
 support extension points in the above normative deliverables. The
 Working Group expects to produce the following registries, but it will
 adjust this list as needed to support the normative deliverables:

--- a/index.html
+++ b/index.html
@@ -306,10 +306,11 @@ disclosure and other modern cryptographic schemes.
             Registries
           </h3>
           <p>
-The Working Group will deliver a set of registries on the <a href="https://www.w3.org/2021/Process-20211102/#registries">W3C Registry Track</a> to
-support extension points in the above normative deliverables. The
-Working Group expects to produce the following registries, but it will
-adjust this list as needed to support the normative deliverables:
+The Working Group may deliver a set of registries on the
+<a href="https://www.w3.org/2021/Process-20211102/#registries">W3C Registry Track</a>
+to support extension points in the above normative deliverables. The Working
+Group might produce the following registries and will adjust this list
+as needed to support the normative deliverables:
           </p>
           <table>
             <tr>

--- a/index.html
+++ b/index.html
@@ -320,10 +320,11 @@ adjust this list as needed to support the normative deliverables:
             </tr>
             <tr>
               <td>
-Verifiable Credential Extensions Registry
+Verifiable Credential Properties Registry
               </td>
               <td>
-A registry of extensions to the Verifiable Credentials Data Model specification.
+A registry of extensions to properties used in the Verifiable Credentials Data
+Model specification.
               </td>
               <td>
 <a href="https://w3c-ccg.github.io/vc-extension-registry/">Verifiable Credential Extensions Registry</a>
@@ -335,7 +336,7 @@ Cryptographic Container and Suite Registry
               </td>
               <td>
 A registry of cryptographic container formats and cryptographic suites that
-are useful in conjunction with specifications managed by this Working Group
+are useful in conjunction with specifications managed by this Working Group.
               </td>
               <td>
 <a href="https://w3c-ccg.github.io/security-vocab/#classes">Classes in CCG Security Vocabulary</a>

--- a/index.html
+++ b/index.html
@@ -339,7 +339,7 @@ A registry of cryptographic container formats and cryptographic suites that
 are useful in conjunction with specifications managed by this Working Group.
               </td>
               <td>
-<a href="https://w3c-ccg.github.io/security-vocab/#classes">Classes in CCG Security Vocabulary</a>
+<a href="https://w3c-ccg.github.io/security-vocab/#classes">Classes in Security Vocabulary</a>
               </td>
             </tr>
             <tr>

--- a/index.html
+++ b/index.html
@@ -316,38 +316,51 @@ adjust this list as needed to support the normative deliverables:
             <tr>
               <th>Registry</th>
               <th>Description</th>
+              <th>Based on</th>
             </tr>
             <tr>
               <td>
-<a href="https://w3c-ccg.github.io/vc-extension-registry/">Verifiable Credential Extensions Registry</a>
+Verifiable Credential Extensions Registry
               </td>
               <td>
 A registry of extensions to the Verifiable Credentials Data Model specification.
               </td>
+              <td>
+<a href="https://w3c-ccg.github.io/vc-extension-registry/">Verifiable Credential Extensions Registry</a>
+              </td>
             </tr>
             <tr>
               <td>
-<a href="https://w3c-ccg.github.io/security-vocab/#classes">Cryptographic Container and Suite Registry</a>
+Cryptographic Container and Suite Registry
               </td>
               <td>
 A registry of cryptographic container formats and cryptographic suites that
 are useful in conjunction with specifications managed by this Working Group
               </td>
+              <td>
+<a href="https://w3c-ccg.github.io/security-vocab/#classes">Classes in CCG Security Vocabulary</a>
+              </td>
             </tr>
             <tr>
               <td>
-<a href="https://w3c.github.io/did-spec-registries/#verification-method-types">Verification Method Registry</a>
+Verification Method Registry
               </td>
               <td>
 A registry of <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-verification-method">verification methods</a>.
               </td>
+              <td>
+<a href="https://w3c.github.io/did-spec-registries/#verification-method-types">Verification Methods in DID Registry</a>
+              </td>
             </tr>
             <tr>
               <td>
-<a href="https://w3c.github.io/did-spec-registries/#verification-relationships">Verification Relationship Registry</a>
+Verification Relationship Registry
               </td>
               <td>
 A registry of <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-verification-relationship">verification relationships</a>.
+              </td>
+              <td>
+<a href="https://w3c.github.io/did-spec-registries/#verification-relationships">Verification Relationships in DID Registry</a>
               </td>
             </tr>
           </table>

--- a/index.html
+++ b/index.html
@@ -301,6 +301,55 @@ disclosure and other modern cryptographic schemes.
           </table>
         </section>
 
+        <section id="normative">
+          <h3>
+            Registries
+          </h3>
+          <p>
+A series of at least the following registries that support the normative
+deliverables of the Working Group will be published and maintained:
+          </p>
+          <table>
+            <tr>
+              <th>Registry</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>
+<a href="https://w3c-ccg.github.io/vc-extension-registry/">Verifiable Credential Extensions Registry</a>
+              </td>
+              <td>
+A registry of extensions to the Verifiable Credentials Data Model specification.
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a href="https://w3c-ccg.github.io/security-vocab/#classes">Cryptographic Container and Suite Registry</a>
+              </td>
+              <td>
+A registry of cryptographic container formats and cryptographic suites that
+are useful in conjunction with specifications managed by this Working Group
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a href="https://w3c.github.io/did-spec-registries/#verification-method-types">Verification Method Registry</a>
+              </td>
+              <td>
+A registry of <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-verification-method">verification methods</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a href="https://w3c.github.io/did-spec-registries/#verification-relationships">Verification Relationship Registry</a>
+              </td>
+              <td>
+A registry of <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-verification-relationship">verification relationships</a>.
+              </td>
+            </tr>
+          </table>
+        </section>
+
         <section id="ig-other-deliverables">
           <h3>
             Other Deliverables

--- a/index.html
+++ b/index.html
@@ -306,65 +306,12 @@ disclosure and other modern cryptographic schemes.
             Registries
           </h3>
           <p>
-The Working Group may deliver a set of registries on the
-<a href="https://www.w3.org/2021/Process-20211102/#registries">W3C Registry Track</a>
-to support extension points in the above normative deliverables. The Working
-Group might produce the following registries and will adjust this list
-as needed to support the normative deliverables:
+The Working Group may create a set of
+<a href="https://www.w3.org/2021/Process-20211102/#registries">registries</a>
+including <a href="https://www.w3.org/2021/Process-20211102/#registry-definition">registry definitions</a>
+and <a href="https://www.w3.org/2021/Process-20211102/#registry-table">registry tables</a>
+to support extension points in the above normative deliverables.
           </p>
-          <table>
-            <tr>
-              <th>Registry</th>
-              <th>Description</th>
-              <th>Based on</th>
-            </tr>
-            <tr>
-              <td>
-Verifiable Credential Properties Registry
-              </td>
-              <td>
-A registry of extensions to properties used in the Verifiable Credentials Data
-Model specification.
-              </td>
-              <td>
-<a href="https://w3c-ccg.github.io/vc-extension-registry/">Verifiable Credential Extensions Registry</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-Cryptographic Container and Suite Registry
-              </td>
-              <td>
-A registry of cryptographic container formats and cryptographic suites that
-are useful in conjunction with specifications managed by this Working Group.
-              </td>
-              <td>
-<a href="https://w3c-ccg.github.io/security-vocab/#classes">Classes in Security Vocabulary</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-Verification Method Registry
-              </td>
-              <td>
-A registry of <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-verification-method">verification methods</a>.
-              </td>
-              <td>
-<a href="https://w3c.github.io/did-spec-registries/#verification-method-types">Verification Methods in DID Registry</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-Verification Relationship Registry
-              </td>
-              <td>
-A registry of <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-verification-relationship">verification relationships</a>.
-              </td>
-              <td>
-<a href="https://w3c.github.io/did-spec-registries/#verification-relationships">Verification Relationships in DID Registry</a>
-              </td>
-            </tr>
-          </table>
         </section>
 
         <section id="ig-other-deliverables">

--- a/index.html
+++ b/index.html
@@ -311,8 +311,9 @@ The Working Group may create a set of
 including <a href="https://www.w3.org/2021/Process-20211102/#registry-definition">registry definitions</a>
 and <a href="https://www.w3.org/2021/Process-20211102/#registry-table">registry tables</a>
 to support extension points in the above normative deliverables. Registries for
-extension points that are required by any of the above normative deliverables
-must have at least one standardized entry.
+extension points that are mandatory to use, for any of the above normative 
+deliverables (for example, Verifiable Credential properties that MUST be included in 
+a Verifiable Credential), must have at least one standardized entry.
           </p>
         </section>
 


### PR DESCRIPTION
This PR build on PR #98 to address Issue #67. 

It adds language that requires registry entries for normatively required extensions to have at least one standardized entry.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-wg-charter/pull/101.html" title="Last updated on Mar 8, 2022, 8:44 PM UTC (99e4ca1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/101/bb419e2...brentzundel:99e4ca1.html" title="Last updated on Mar 8, 2022, 8:44 PM UTC (99e4ca1)">Diff</a>