### PR TITLE
renaming a deliverable to "Securing Verifiable Credentials 1.0"

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@ Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08
             </dd>
           </dl>
           <dl>
-            <dt id="data-integrity-1" class="spec">Verifiable Credential Data Integrity (VCDI) 1.0</dt>
+            <dt id="data-integrity-1" class="spec">Securing Verifiable Credentials (SVC) 1.0</dt>
             <dd>
               <p>
 This family of specifications consists of documents that each define how to
@@ -365,9 +365,9 @@ listed here.
             <li>WG-START +1 month: First teleconference</li>
             <li>WG-START +2 months: FPWD for VCDM 2.0</li>
             <li>WG-START +5 months: First face-to-face meeting</li>
-            <li>WG-START +6 months: FPWD for VCDI 1.0</li>
+            <li>WG-START +6 months: FPWD for SVC 1.0</li>
             <li>WG-START +14 months: CR for VCDM 2.0</li>
-            <li>WG-START +18 months: CR for VCDI 1.0</li>
+            <li>WG-START +18 months: CR for SVC 1.0</li>
             <li>WG-START +24 months: REC for all standards-track documents</li>
           </ul>
         </section>


### PR DESCRIPTION
Adopting @msporny 's proposal "Securing Verifiable Credentials 1.0" as an alternative to "Verifiable Credential Data Integrity 1.0" per discussion in Issue #87.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Sakurann/vc-wg-charter/pull/102.html" title="Last updated on Mar 8, 2022, 7:03 PM UTC (9f1e517)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/102/e4fc1ad...Sakurann:9f1e517.html" title="Last updated on Mar 8, 2022, 7:03 PM UTC (9f1e517)">Diff</a>