### PR TITLE
Add Koblitz ECDSA Recovery Cryptosuite

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,8 +266,9 @@ following are a non-exhaustive selection of expected input documents:
           </h3>
           <p>
 Depending on progress in the
-<a href="https://www.w3.org/community/credentials/">W3C Credentials Community Group</a>
-and the <a href="https://www.ietf.org/">IETF</a>, the Working Group may also
+<a href="https://www.w3.org/community/credentials/">W3C Credentials Community Group</a>,
+the <a href="https://www.ietf.org/">IETF</a>,
+and the <a href="https://identity.foundation/">DIF</a>, the Working Group may also
 produce W3C Recommendations based on the following documents:
           </p>
 
@@ -310,6 +311,17 @@ disclosure and other modern cryptographic schemes.
               </td>
               <td>
 <a href="https://json-web-proofs.github.io/json-web-proofs/">VC-JSON Web Proof (JWP)</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                  Koblitz ECDSA Recovery Cryptosuite
+              </td>
+              <td>
+A cryptographic digital signature suite supporting elliptic curve public key recovery.
+              </td>
+              <td>
+<a href="https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/">Secp256k1 Recovery Cryptosuite</a>
               </td>
             </tr>
           </table>


### PR DESCRIPTION
I'd like to offer this cryptosuite for recoverable ECDSA signatures as a possible input document in the purview of the WG: https://github.com/decentralized-identity/EcdsaSecp256k1RecoverySignature2020

The "Public Key Recovery Operation" is described in section 4.1.6 of [SEC 1 v2.0](https://www.secg.org/sec1-v2.pdf).

Sorry this is a bit late.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/spruceid/vc-wg-charter/pull/105.html" title="Last updated on Mar 23, 2022, 4:47 PM UTC (df16fde)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/105/0b6f3cd...spruceid:df16fde.html" title="Last updated on Mar 23, 2022, 4:47 PM UTC (df16fde)">Diff</a>