### PR TITLE
updating algorithms-related reference documents for jwt-vcs

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,11 +244,10 @@ its scope will be to solve Verifiable Credentials use cases. The specific set of
 concrete serializations included will be determined by the Working Group. The
 following are a non-exhaustive selection of expected input documents:
               </p>
-              <p class="input-documents"><b>Container Formats:</b>
-                <a href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JSON Web Token (JWT)</a>,
-                <a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a>
+              <p class="input-documents"><b>Cryptosuites for <a href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JSON Web Token (JWT)</a>:</b>
+                <a href="https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms">IANA JOSE Algorithms Registry</a>
               </p>
-              <p class="input-documents"><b>Cryptosuites:</b>
+              <p class="input-documents"><b>Cryptosuites for <a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a>:</b>
                 <a href="https://github.com/w3c-ccg/lds-jws2020/">JSON Web Signature 2020</a>,
                 <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">EdDSA</a>,
                 <a href="https://w3c-ccg.github.io/di-ecdsa-secpr1-2019/">NIST ECDSA</a>,


### PR DESCRIPTION
Addresses issue #88 as discussed in the last WG call.

I ended up using [IANA JOSE Algorithms Registry](https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms) since it references all the RFCs that I and Orie have been suggesting (see [comment](https://github.com/w3c/vc-wg-charter/issues/88#issuecomment-1058088662))


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/pull/107.html" title="Last updated on Mar 29, 2022, 10:48 PM UTC (c557147)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/107/94f8fbe...c557147.html" title="Last updated on Mar 29, 2022, 10:48 PM UTC (c557147)">Diff</a>