### PR TITLE
Adding registry content reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@ The <b>scope</b> of the Verifiable Credentials Working Group is:
                 <li>Presentations and Verifiable Presentations</li>
                 <li>requests for or submissions of Verifiable Credentials or Verifiable Presentations</li>
             </ul>
-          <li>Registries for the data model</li>
+          <li>Registries for the data model to support extension points in the normative deliverables.</li>
           <li>Algorithms for the expression and verification of proofs that use existing cryptographic primitives</li>
           <li>Refining multilingual support in the data model</li>
         </ul>


### PR DESCRIPTION
Add a reference to the quote section on what the registries are aimed at doing.

Just copied a sentence from section 2.3 into the relevant line in the listed in-scope items.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/pull/109.html" title="Last updated on Apr 29, 2022, 12:55 PM UTC (29bbdcf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/109/756cb2b...29bbdcf.html" title="Last updated on Apr 29, 2022, 12:55 PM UTC (29bbdcf)">Diff</a>