### PR TITLE
Extension proposal for the coming two years

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 
-    <title>[DRAFT] Verifiable Credentials Working Group Charter</title>
+    <title>Verifiable Credentials Working Group Charter</title>
 
     <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
@@ -71,7 +71,7 @@
 
 
     <main>
-      <h1 id="title">Verifiable Credentials Working Group Charter</h1>
+      <h1 id="title">[PROPOSED] Verifiable Credentials Working Group Charter</h1>
       <!-- delete PROPOSED after AC review completed -->
 
       <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/2017/vc/WG/">Verifiable Credentials Working Group</a> is to make expressing, exchanging, and verifying credentials easier and more secure on the web.</p>
@@ -111,7 +111,7 @@
               End date
             </th>
             <td>
-              30 June 2024
+              30 June 2026
             </td>
           </tr>
           <tr>
@@ -166,9 +166,12 @@
           <li>Algorithms for the expression and verification of proofs that use existing cryptographic primitives</li>
           <li>Refining multilingual support in the data model</li>
         </ul>
-	<p>
-	  It is explicitly not a requirement that the new specifications be fully compatible with related past specifications.
-	</p>
+        <p>
+          It is explicitly not a requirement that the new specifications be fully compatible with related past specifications.
+        </p>
+        <p>
+          Once all the planned Recommendations have been published, the Working Group will continue in maintenance mode to handle errata. No new Recommendations are planned. <a href="https://www.w3.org/2023/Process-20231103/#class-4">Class 4 changes</a> for Recommendations published by the Working Group are <strong>out of scope</strong>, <em><strong>except</strong></em> if serious security issues come to the fore that require changes in a Recommendation.
+        </p>
         <section id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>
           <p>The following features are <b>out of scope</b>, and will not be addressed by the Verifiable Credentials Working group:</p>
@@ -831,7 +834,7 @@
       </address>
 
       <p class="copyright">
-        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©2023
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©2024
         <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>.
 
         <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-US">
+
   <head>
     <meta charset="utf-8">
 
@@ -26,11 +27,11 @@
         background: yellow;
       }
 
-      ul.out-of-scope > li {
+      ul.out-of-scope>li {
         font-weight: bold;
       }
 
-      ul.out-of-scope > li > ul > li{
+      ul.out-of-scope>li>ul>li {
         font-weight: normal;
       }
 
@@ -46,15 +47,17 @@
       footer {
         font-size: small;
       }
+
     </style>
   </head>
+
   <body>
     <header id="header">
       <aside>
         <ul id="navbar">
           <li><a href="#scope">Scope</a></li>
           <li><a href="#deliverables">Deliverables</a></li>
-		      <li><a href="#success-criteria">Success Criteria</a></li>
+          <li><a href="#success-criteria">Success Criteria</a></li>
           <li><a href="#coordination">Coordination</a></li>
           <li><a href="#participation">Participation</a></li>
           <li><a href="#communication">Communication</a></li>
@@ -74,17 +77,22 @@
       <h1 id="title">[PROPOSED] Verifiable Credentials Working Group Charter</h1>
       <!-- delete PROPOSED after AC review completed -->
 
-      <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/2017/vc/WG/">Verifiable Credentials Working Group</a> is to make expressing, exchanging, and verifying credentials easier and more secure on the web.</p>
+      <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/2017/vc/WG/">Verifiable
+          Credentials Working Group</a> is to make expressing, exchanging, and verifying credentials easier and more
+        secure on the web.</p>
 
       <p class="motivation">
-          Readers that are new to this work should read the <a href="https://www.w3.org/TR/vc-data-model/">latest Verifiable
-          Credentials Data Model</a>. The <a href="https://www.w3.org/TR/vc-data-model/#introduction">Introduction</a> and
-          <a href="https://www.w3.org/TR/vc-data-model/#terminology">Terminology</a> may be particularly helpful to W3C Members
-          seeking to better understand some the terminology used in this charter e.g., Credentials vs. Verifiable Credentials and Presentations vs. Verifiable Presentations.
+        Readers that are new to this work should read the <a href="https://www.w3.org/TR/vc-data-model/">latest
+        Verifiable Credentials Data Model</a>. 
+        The <a href="https://www.w3.org/TR/vc-data-model/#introduction">Introduction</a> and
+        <a href="https://www.w3.org/TR/vc-data-model/#terminology">Terminology</a> may be particularly helpful to W3C
+        Members seeking to better understand some the terminology used in this charter e.g., Credentials vs. Verifiable
+        Credentials and Presentations vs. Verifiable Presentations.
       </p>
 
       <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/98922/join">Join the Verifiable Credentials Working Group.</a></p>
+        <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/98922/join">Join the Verifiable Credentials Working
+            Group.</a></p>
       </div>
 
 
@@ -95,7 +103,8 @@
               Charter Status
             </th>
             <td>
-              See the <a href="https://www.w3.org/groups/wg/vc/charters">group status page</a> and <a href="#history">detailed change history</a>.</i>
+              See the <a href="https://www.w3.org/groups/wg/vc/charters">group status page</a> and <a
+                href="#history">detailed change history</a>.</i>
             </td>
           </tr>
           <tr id="Duration">
@@ -103,7 +112,7 @@
               Start date
             </th>
             <td>
-              13 June 2022
+              01 July 2022
             </td>
           </tr>
           <tr id="CharterEnd">
@@ -119,7 +128,7 @@
               Chairs
             </th>
             <td>
-              <a href="mailto:brent.zundel@gmail.com">Brent Zundel</a> (W3C Invited Expert)<br>
+              <a href="mailto:brent.zundel@gmail.com">Brent Zundel</a> (mesur.io)<br>
             </td>
           </tr>
           <tr>
@@ -137,7 +146,8 @@
             <td>
               <strong>Teleconferences:</strong> 1-hour calls will be held weekly, plus additional special-topic calls as needed
               <br>
-              <strong>Face-to-face:</strong> We will meet during the W3C's annual Technical Plenary week; additional face-to-face meetings may be scheduled by consent of the participants, usually no more than 3 per year.
+              <strong>Face-to-face:</strong> We will meet during the W3C's annual Technical Plenary week; additional
+              face-to-face meetings may be scheduled by consent of the participants, usually no more than 3 per year.
             </td>
           </tr>
         </table>
@@ -155,32 +165,43 @@
           The <b>scope</b> of the Verifiable Credentials Working Group is:
         </p>
         <ul>
-          <li>Addressing errata, ambiguities, and interoperability problems found in previous versions of the Verifiable Credentials Data Model</li>
+          <li>
+            Addressing errata, ambiguities, and interoperability problems found in previous versions of the Verifiable
+            Credentials Data Model
+          </li>
           <li>A data model for Verifiable Credentials, inclusive of:</li>
-            <ul>
-                <li>Credentials and Verifiable Credentials</li>
-                <li>Presentations and Verifiable Presentations</li>
-                <li>requests for or submissions of Verifiable Credentials or Verifiable Presentations</li>
-            </ul>
+          <ul>
+            <li>Credentials and Verifiable Credentials</li>
+            <li>Presentations and Verifiable Presentations</li>
+            <li>requests for or submissions of Verifiable Credentials or Verifiable Presentations</li>
+          </ul>
           <li>Registries for the data model to support extension points in the normative deliverables.</li>
           <li>Algorithms for the expression and verification of proofs that use existing cryptographic primitives</li>
           <li>Refining multilingual support in the data model</li>
         </ul>
         <p>
-          It is explicitly not a requirement that the new specifications be fully compatible with related past specifications.
+          It is explicitly not a requirement that the new specifications be fully compatible with related past
+          specifications.
         </p>
         <p>
-          Once all the planned Recommendations have been published, the Working Group will continue in maintenance mode to handle errata. No new Recommendations are planned. <a href="https://www.w3.org/2023/Process-20231103/#class-4">Class 4 changes</a> for Recommendations published by the Working Group are <strong>out of scope</strong>, <em><strong>except</strong></em> if serious security issues come to the fore that require changes in a Recommendation.
+          Once all the planned Recommendations have been published, the Working Group will continue in maintenance mode
+          to handle errata. No new Recommendations are planned. <a  href="https://www.w3.org/2023/Process-20231103/#class-4">Class 4 changes</a> 
+          for Recommendations published by the Working Group are <strong>out of scope</strong>, <em><strong>except</strong></em> if serious security
+          issues come to the fore that require changes in a Recommendation.
         </p>
         <section id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>
-          <p>The following features are <b>out of scope</b>, and will not be addressed by the Verifiable Credentials Working group:</p>
+          <p>
+            The following features are <b>out of scope</b>, and will not be addressed by the Verifiable Credentials
+            Working group:
+          </p>
 
-            <ul class="out-of-scope">
-              <li>The mandate of any specific style of supporting infrastructure, such as a Distributed Ledger (DLT), for a Verifiable Credentials ecosystem</li>
-              <li>The specification of new cryptographic primitives</li>
-              <li>The normative specification of APIs or protocols</li>
-            </ul>
+          <ul class="out-of-scope">
+            <li>The mandate of any specific style of supporting infrastructure, such as a Distributed Ledger (DLT), for
+              a Verifiable Credentials ecosystem</li>
+            <li>The specification of new cryptographic primitives</li>
+            <li>The normative specification of APIs or protocols</li>
+          </ul>
         </section>
 
       </section>
@@ -190,9 +211,15 @@
           Deliverables
         </h2>
 
-        <p>Updated document status is available on the <a href="https://www.w3.org/groups/wg/vc/publications">group publication status page</a>.</p>
+        <p>
+          Updated document status is available on the <a href="https://www.w3.org/groups/wg/vc/publications">group publication status page</a>.
+        </p>
 
-        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
+        <p>
+          <i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected
+          completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a
+          stable state.
+        </p>
 
         <section id="normative">
           <h3>
@@ -205,55 +232,232 @@
             <dt id="verifiable-credentials-data-model-2" class="spec">Verifiable Credentials Data Model (VCDM) 2.0</dt>
             <dd>
               <p>
-                This specification defines the Verifiable Credentials Data Model 2.0 along with
-                serializations of that data model. It will replace the current
-                <a href="https://www.w3.org/TR/vc-data-model/">Verifiable Credentials Data Model 1.1 Recommendation</a>.
+                This specification defines the Verifiable Credentials Data Model 2.0 along with serializations of that
+                data model. It will replace the current <a href="https://www.w3.org/TR/vc-data-model/">Verifiable
+                Credentials Data Model 1.1 Recommendation</a>.
               </p>
 
-              <p class="draft-status"><b>Draft state:</b> <a href="https://w3c.github.io/vc-data-model/">Editor's Draft</a> </p>
-              <p class="milestone"><b>Expected completion:</b> 30 June 2024</p>
-              <dl>
-                <dt>
-                  <p>
-                      <b>Adopted Draft:</b> <a href='https://w3c.github.io/vc-data-model/'>Verifiable Credentials Data Model 1.1</a>
-                  </p>
-                  <p>
-                      <b>Exclusion Draft:</b>
-                      <a href='https://www.w3.org/TR/2021/REC-vc-data-model-20211109/'>Verifiable Credentials Data Model 1.1</a>
-                      Exclusion period <b>began</b> 11 November 2021; Exclusion period <b>ended</b> 08 January 2022.
-                  </p>
-                  <p>
-                      <b>Other Charter:</b> <a href="https://www.w3.org/2020/12/verifiable-credentials-wg-charter.html"> https://www.w3.org/2020/12/verifiable-credentials-wg-charter.html</a>
-                  </p>
-                </dd>
-              </dl>
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/vc-data-model-2.0/">Candidate Recommendation</a></p>
+
+              <p class="milestone"><b>Expected completion:</b> 2025-01-31</p>
+
+              <p>
+                <b>Adopted Draft:</b> <a href='https://www.w3.org/TR/vc-data-model-2.0/'>Verifiable Credentials Data
+                Model v2.0</a>
+              </p>
+
+              <p>
+                <b>Exclusion Draft:</b>
+                <a href='https://www.w3.org/TR/2024/CR-vc-data-model-2.0-20240201/'>Verifiable Credentials Data Model
+                2.0 (CR Snapshot)</a>
+                Exclusion period <b>began</b> 2024-02-01; Exclusion period <b>ended</b> 2024-04-01.
+              </p>
+
+              <p>
+                <b>Exclusion Draft Charter:</b> https://www.w3.org/2022/06/verifiable-credentials-wg-charter.html</b>
+              </p>
             </dd>
           </dl>
           <dl>
-            <dt id="data-integrity-1" class="spec">Securing Verifiable Credentials (SVC) 1.0</dt>
+            <dt id="data-integrity-1" class="spec">Verifiable Credential Data Integrity 1.0</dt>
             <dd>
               <p>
-                  This family of specifications consists of documents that each define how to
-                  express and associate proofs of integrity for Verifiable Credentials and
-                  concrete serializations for each of the defined syntaxes. The Working Group
-                  would welcome the usage of these techniques for data in general, but
-                  its scope will be to solve Verifiable Credentials use cases. The specific set of
-                  concrete serializations included will be determined by the Working Group. The
-                  following are a non-exhaustive selection of expected input documents:
+                This specification is a general framework to associate proofs of integrity for Verifiable Credentials
+                and concrete serializations for each of the defined syntaxes.
+                The Working Group would welcome the usage of these techniques for data in general, but
+                its scope will be to solve Verifiable Credentials use cases. The specific set of
+                concrete serializations and cryptosuites appear as separate
+                specification, all part of the same family of specifications.
               </p>
-              <p class="input-documents"><b>Cryptosuites for <a href="https://w3c.github.io/vc-data-model/#json-web-token">VC-JSON Web Token (JWT)</a>:</b>
-                <a href="https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms">IANA JOSE Algorithms Registry</a>
+
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/vc-data-integrity/">Candidate Recommendation</a></p>
+
+              <p class="milestone"><b>Expected completion:</b> 2025-01-31</p>
+
+              <p>
+                <b>Adopted Draft:</b> <a href='https://www.w3.org/TR/vc-data-integrity/'>Verifiable Credential Data Integrity 1.0</a>
               </p>
-              <p class="input-documents"><b>Cryptosuites for <a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a>:</b>
-                <a href="https://github.com/w3c-ccg/lds-jws2020/">JSON Web Signature 2020</a>,
-                <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">EdDSA</a>,
-                <a href="https://w3c-ccg.github.io/di-ecdsa-secpr1-2019/">NIST ECDSA</a>,
-                <a href="https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/">Koblitz ECDSA</a>
+
+              <p>
+                <b>Exclusion Draft:</b>
+                <a href='https://www.w3.org/TR/2023/CR-vc-data-integrity-20231121/'>Verifiable Credential Data Integrity 1.0 (CR Snapshot)</a>
+                Exclusion period <b>began</b> 2023-11-21; Exclusion period <b>ended</b> 2024-01-20.
               </p>
-              <p class="milestone"><b>Expected completion:</b>30 June 2024</p>
+
+              <p>
+                <b>Exclusion Draft Charter:</b> https://www.w3.org/2022/06/verifiable-credentials-wg-charter.html</b>
+              </p>
             </dd>
           </dl>
 
+          <dl>
+            <dt id="json-schema" class="spec">Verifiable Credentials JSON Schema Specification</dt>
+            <dd>
+              <p>
+                This specification provides a mechanism to make use of a Credential Schema in Verifiable Credential,
+                leveraging the existing Data Schemas concept.
+              </p>
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/vc-json-schema/">Candidate Recommendation</a></p>
+
+              <p class="milestone"><b>Expected completion:</b> 2025-01-31</p>
+
+              <p>
+                <b>Adopted Draft:</b> <a href='https://www.w3.org/TR/vc-json-schema/'>Verifiable Credentials JSON Schema Specification</a>
+              </p>
+
+              <p>
+                <b>Exclusion Draft:</b>
+                <a href='https://www.w3.org/TR/2023/CR-vc-json-schema-20231121/'>Verifiable Credentials JSON Schema Specification (CR Snapshot)</a>
+                Exclusion period <b>began</b> 2023-11-21; Exclusion period <b>ended</b> 2024-01-20.
+              </p>
+
+              <p>
+                <b>Exclusion Draft Charter:</b> https://www.w3.org/2022/06/verifiable-credentials-wg-charter.html</b>
+              </p>
+            </dd>
+          </dl>
+
+          <dl>
+            <dt id="ecdsa" class="spec">Data Integrity ECDSA Cryptosuites v1.0</dt>
+            <dd>
+              <p>
+                This specification describes a Data Integrity Cryptosuite for use when generating a digital signature
+                using the Elliptic Curve Digital Signature Algorithm (ECDSA).
+              </p>
+
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/vc-di-ecdsa/">Candidate Recommendation</a></p>
+
+              <p class="milestone"><b>Expected completion:</b> 2025-01-31</p>
+
+              <p>
+                <b>Adopted Draft:</b> <a href='https://www.w3.org/TR/vc-di-ecdsa/'>Data Integrity ECDSA Cryptosuites v1.0</a>
+              </p>
+
+              <p>
+                <b>Exclusion Draft:</b>
+                <a href='https://www.w3.org/TR/2023/CR-vc-di-ecdsa-20231121/'>Data Integrity ECDSA Cryptosuites v1.0 (CR Snapshot)</a> 
+                Exclusion period <b>began</b> 2023-11-21; Exclusion period <b>ended</b> 2024-01-20.
+              </p>
+
+              <p>
+                <b>Exclusion Draft Charter:</b> https://www.w3.org/2022/06/verifiable-credentials-wg-charter.html</b>
+              </p>
+            </dd>
+          </dl>
+
+          <dl>
+            <dt id="eddsa" class="spec">Data Integrity EdDSA Cryptosuites v1.0</dt>
+            <dd>
+              <p>
+                This specification describes a Data Integrity cryptographic suite for use when creating or verifying a digital signature 
+                using the twisted Edwards Curve Digital Signature Algorithm (EdDSA) and Curve25519 (ed25519).
+              </p>
+
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/vc-di-eddsa/">Candidate Recommendation</a></p>
+
+              <p class="milestone"><b>Expected completion:</b> 2025-01-31</p>
+
+              <p>
+                <b>Adopted Draft:</b> <a href='https://www.w3.org/TR/vc-di-eddsa/'>Data Integrity EdDSA Cryptosuites
+                  v1.0</a>
+              </p>
+
+              <p>
+                <b>Exclusion Draft:</b>
+                <a href='https://www.w3.org/TR/2023/CR-vc-di-eddsa-20231121/'>Data Integrity EdDSA Cryptosuites v1.0 (CR Snapshot)</a>
+                Exclusion period <b>began</b> 2023-11-21; Exclusion period <b>ended</b> 2024-01-20.
+              </p>
+
+              <p>
+                <b>Exclusion Draft Charter:</b> https://www.w3.org/2022/06/verifiable-credentials-wg-charter.html</b>
+              </p>
+            </dd>
+          </dl>
+
+          <dl>
+            <dt id="bbs" class="spec">Data Integrity BBS Cryptosuites v1.0</dt>
+            <dd>
+              <p>
+                This specification describes a Data Integrity Cryptosuite for use when generating digital signatures
+                using the BBS signature scheme. The Signature Suite utilizes BBS signatures to provide selective
+                disclosure and unlinkable derived proofs.
+              </p>
+
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/vc-di-bbs/">Working Draft</a> </p>
+
+              <p class="milestone"><b>Expected completion:</b> 2025-01-31</p>
+
+              <p>
+                <b>Adopted Draft:</b> <a href='https://www.w3.org/TR/vc-di-bbs/'>Data Integrity BBS Cryptosuites
+                  v1.0</a>
+              </p>
+
+              <p>
+                <b>Exclusion Draft:</b>
+                <a href='https://www.w3.org/TR/2023/WD-vc-di-bbs-20230518/'>BBS Cryptosuite v2023 (First Public Working Draft)</a>
+                Exclusion period <b>began</b> 2023-05-18; Exclusion period <b>ended</b> 2023-10-15.
+              </p>
+
+              <p>
+                <b>Exclusion Draft Charter:</b> https://www.w3.org/2022/06/verifiable-credentials-wg-charter.html</b>
+              </p>
+            </dd>
+          </dl>
+
+          <dl>
+            <dt id="jose-cose" class="spec">Securing Verifiable Credentials using JOSE and COSE</dt>
+            <dd>
+              <p>
+                This specification defines how to secure credentials and presentations conforming to the Verifiable Credential 
+                data model with JSON Object Signing and Encryption (JOSE), Selective Disclosure for JWTs, and 
+                CBOR Object Signing and Encryption (COSE).
+              </p>
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/vc-jwt/">Working Draft</a></p>
+
+              <p class="milestone"><b>Expected completion:</b> 2025-01-31</p>
+
+              <p>
+                <b>Adopted Draft:</b> <a href='https://www.w3.org/TR/vc-jwt/'>Securing Verifiable Credentials using JOSE and COSE</a>
+              </p>
+
+              <p>
+                <b>Exclusion Draft:</b>
+                <a href='https://www.w3.org/TR/2023/WD-vc-jwt-20230427/'>Securing Verifiable Credentials using JSON Web Tokens (First Public Working Draft)</a>
+                Exclusion period <b>began</b> 2023-04-27; Exclusion period <b>ended</b> 2023-09-24.
+              </p>
+
+              <p>
+                <b>Exclusion Draft Charter:</b> https://www.w3.org/2022/06/verifiable-credentials-wg-charter.html</b>
+              </p>
+            </dd>
+          </dl>
+
+          <dl>
+            <dt id="bitstring" class="spec">Bitstring Status List v1.0</dt>
+            <dd>
+              <p>
+                This specification describes a privacy-preserving, space-efficient, and high-performance mechanism for
+                publishing status information such as suspension or revocation of Verifiable Credentials through use of bitstrings.
+              </p>
+
+              <p class="draft-status"> <b>Draft state:</b> <a href="https://www.w3.org/TR/vc-bitstring-status-list/">Working Draft</a></p>
+
+              <p class="milestone"><b>Expected completion:</b> 2025-01-31</p>
+
+              <p>
+                <b>Adopted Draft:</b> <a href='https://www.w3.org/TR/vc-bitstring-status-list/'>Bitstring Status List v1.0</a>
+              </p>
+
+              <p>
+                <b>Exclusion Draft:</b>
+                <a href='https://www.w3.org/TR/2023/WD-vc-status-list-20230427/'>Verifiable Credentials Status List v2021 (First Public Working Draft)</a>
+                Exclusion period <b>began</b> 2023-04-27; Exclusion period <b>ended</b> 2023-09-24.
+              </p>
+              <p>
+                <b>Exclusion Draft Charter:</b> https://www.w3.org/2022/06/verifiable-credentials-wg-charter.html</b>
+              </p>
+            </dd>
+          </dl>
         </section>
 
         <section id="conditional-normative">
@@ -261,11 +465,11 @@
             Conditional Normative Specifications
           </h3>
           <p>
-              Depending on progress in the
-              <a href="https://www.w3.org/community/credentials/">W3C Credentials Community Group</a>,
-              the <a href="https://www.ietf.org/">IETF</a>,
-              and the <a href="https://identity.foundation/">DIF</a>, the Working Group may also
-              produce W3C Recommendations based on the following documents:
+            Depending on progress in the
+            <a href="https://www.w3.org/community/credentials/">W3C Credentials Community Group</a>,
+            the <a href="https://www.ietf.org/">IETF</a>,
+            and the <a href="https://identity.foundation/">DIF</a>, the Working Group may also
+            produce W3C Recommendations based on the following documents:
           </p>
 
           <table>
@@ -276,59 +480,49 @@
             </tr>
             <tr>
               <td>
-                  PGP&nbsp;Cryptosuite
+                PGP&nbsp;Cryptosuite
               </td>
               <td>
-                  A cryptographic digital signature suite that utilizes Pretty Good Privacy [<a
+                A cryptographic digital signature suite that utilizes Pretty Good Privacy [<a
                   href="https://datatracker.ietf.org/doc/html/rfc4880">RFC4880</a>].
               </td>
               <td>
-                  <a href="https://or13.github.io/lds-pgp2021/">PGP&nbsp;Cryptosuite</a>
+                <a href="https://or13.github.io/lds-pgp2021/">PGP&nbsp;Cryptosuite</a>
               </td>
             </tr>
             <tr>
               <td>
-                  BBS+&nbsp;Cryptosuite
+                Verifiable Credential Protection Using JWPs
               </td>
               <td>
-                  A cryptographic digital signature suite supporting selective disclosure.
+                A cryptographic container format for expressing JWT-like proofs for selective
+                disclosure and other modern cryptographic schemes.
               </td>
               <td>
-                  <a href="https://w3c-ccg.github.io/ldp-bbs2020/">BBS+&nbsp;Cryptosuite</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                  Verifiable Credential Protection Using JWPs
-              </td>
-              <td>
-                  A cryptographic container format for expressing JWT-like proofs for selective
-                  disclosure and other modern cryptographic schemes.
-              </td>
-              <td>
-                  <a href="https://json-web-proofs.github.io/json-web-proofs/">VC-JSON Web Proof (JWP)</a>
+                <a href="https://json-web-proofs.github.io/json-web-proofs/">VC-JSON Web Proof (JWP)</a>
               </td>
             </tr>
             <tr>
               <td>
-                  Koblitz ECDSA Recovery Cryptosuite
+                Koblitz ECDSA Recovery Cryptosuite
               </td>
               <td>
-                  A cryptographic digital signature suite supporting elliptic curve public key recovery.
+                A cryptographic digital signature suite supporting elliptic curve public key recovery.
               </td>
               <td>
-                  <a href="https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/">Secp256k1 Recovery Cryptosuite</a>
+                <a href="https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/">Secp256k1 Recovery
+                  Cryptosuite</a>
               </td>
             </tr>
           </table>
           <p>
-              Other cryptographic suites for
-              <a href="https://datatracker.ietf.org/doc/html/rfc8017">NIST RSA</a>,
-              <a href="https://datatracker.ietf.org/doc/html/rfc4490">EASC DSA</a>,
-              <a href="https://standards.ieee.org/ieee/1363.3/3822/">SM9 IBSA</a>,
-              <a href="https://csrc.nist.gov/Projects/post-quantum-cryptography">NIST post-quantum cryptography</a>,
-              or other externally standardized cryptographic primitives may be produced under
-              the same conditions as the table above.
+            Other cryptographic suites for
+            <a href="https://datatracker.ietf.org/doc/html/rfc8017">NIST RSA</a>,
+            <a href="https://datatracker.ietf.org/doc/html/rfc4490">EASC DSA</a>,
+            <a href="https://standards.ieee.org/ieee/1363.3/3822/">SM9 IBSA</a>,
+            <a href="https://csrc.nist.gov/Projects/post-quantum-cryptography">NIST post-quantum cryptography</a>,
+            or other externally standardized cryptographic primitives may be produced under
+            the same conditions as the table above.
           </p>
         </section>
 
@@ -353,22 +547,28 @@
             Other Deliverables
           </h3>
           <p>
-            Other non-normative documents may be created as time, attention, and resources permit. The following list is a
-            non-exhaustive selection of documents the Working Group may wish to produce. The Working
-            Group will use its discretion to decide which, if any, to work on, and may publish WG Notes or other documents not
-            listed here.
+            Other non-normative documents may be created as time, attention, and resources permit. The following list is
+            a non-exhaustive selection of documents the Working Group may wish to produce. The Working Group will 
+            use its discretion to decide which, if any, to work on, and may publish WG Notes or other documents 
+            not listed here.
           </p>
+
           <ul>
             <li>Test suites for all normative deliverables</li>
             <li>Presentation Request Data Model</li>
             <li>Storage and Sharing of Verifiable Credentials</li>
             <li>Privacy Guidance for Verifiable Credentials</li>
             <li>Extensions for binding multilingual resources for localized user interfaces</li>
-            <li>A Developer Guide consisting of one or more notes related to general implementation guidance and best practices for working with Verifiable Credentials, including but not limited to:
+            <li>A Developer Guide consisting of one or more notes related to general implementation guidance and best
+              practices for working with Verifiable Credentials, including but not limited to:
               <ul>
-                <li>One or more HTTP protocol definitions for Verifiable Credential Exchange (such as the <a href="https://w3c-ccg.github.io/vc-api/">VC-API</a>)</li>
-                <li>Guidance on Verifiable Credential Exchange over <a href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect</a></li>
-                <li>Verifiable Credential Exchange over <a href="https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol">Grant Negotiation and Authorization Protocol (GNAP)</a></li>
+                <li>One or more HTTP protocol definitions for Verifiable Credential Exchange (such as the <a
+                    href="https://w3c-ccg.github.io/vc-api/">VC-API</a>)</li>
+                <li>Guidance on Verifiable Credential Exchange over <a
+                    href="https://openid.net/specs/openid-connect-core-1_0.html">OpenID Connect</a></li>
+                <li>Verifiable Credential Exchange over <a
+                    href="https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol">Grant Negotiation and
+                    Authorization Protocol (GNAP)</a></li>
                 <li>Other protocols as time, attention, and resources permit.</li>
               </ul>
             </li>
@@ -380,6 +580,7 @@
               </ul>
             </li>
           </ul>
+
           <p>
             The Working Group may also update Notes published under previous charters.
           </p>
@@ -388,13 +589,10 @@
         <section id="timeline">
           <h3>Timeline</h3>
           <ul>
-            <li>June 2022: First teleconference</li>
-            <li>September 2022: FPWD for VCDM 2.0</li>
-            <li>September 2022: First face-to-face meeting</li>
-            <li>January 2023: FPWD for SVC 1.0</li>
-            <li>September 2023: CR for VCDM 2.0</li>
-            <li>January 2024: CR for SVC 1.0</li>
-            <li>June 2024: REC for all standards-track documents</li>
+            <li>July 2024: First teleconference</li>
+            <li>November 2024: Proposed Recommendation for all normative Deliverables</li>
+            <li>January 2025: REC for all standards-track documents</li>
+            <li>February 2025: Working Group begins to operate in maintenance mode</li>
           </ul>
         </section>
       </section>
@@ -403,24 +601,25 @@
         <h2>Success Criteria</h2>
 
         <p>
-          In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>,
-          each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at
-          least two independent implementations</a> of every feature defined in the specification.
+          In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, 
+          each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least 
+          two independent implementations</a> of every feature defined in the specification.
         </p>
 
-        <p>
-          Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.
-        </p>
+        <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 
         <p>
-          There should be testing plans for each specification, starting from the earliest drafts.
+          Each specification should contain separate sections detailing all known security and privacy implications for
+          implementers, Web authors, and end users.
         </p>
+
         <p>
           In order to advance to Proposed Recommendation, each normative specification must have an open test suite
           that tests every feature defined in the specification.
           Additionally, two or more implementations should demonstrate interoperability for each feature
-          by passing these open test suites, and by showing that these implementations may interoperate with each other. 
-          For example Verifiable Credentials produced by implementations must be consumed by other implementations and behave as specified. 
+          by passing these open test suites, and by showing that these implementations may interoperate with each other.
+          For example Verifiable Credentials produced by implementations must be consumed by other implementations and
+          behave as specified.
         </p>
         <p>
           A feature should be understood as a property or set of properties that are normatively required.
@@ -429,91 +628,119 @@
 
       <section id="coordination">
         <h2>Coordination</h2>
-        <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for
+        <p>
+          For all specifications, this Working Group will seek <a
+            href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for
           accessibility, internationalization, performance, privacy, and security with the relevant Working and
           Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
           Invitation for review must be issued during each major standards-track document transition, including
-          <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>.  The
-          Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
-          each specification.  The Working Group is advised to seek a review at least 3 months before first entering
-          <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
-          to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
+          <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>. The
+          Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development
+          of each specification. The Working Group is advised to seek a review at least 3 months before first entering
+          <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is
+          encouraged to proactively notify the horizontal review groups when major changes occur in a specification 
+          following a review.
+        </p>
 
-        <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
+        <p>
+          Additional technical coordination with the following Groups will be made, per the <a
+            href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:
+        </p>
 
         <section>
-            <h3 id="w3c-coordination">W3C Groups</h3>
-            <dl>
-                <dt>RDF Canonicalization and Hashing Working Group</dt>
-                <dd>
-                    To synchronize on canonicalization output expression mechanisms that might be used by the VC Data Integrity specification.
-                </dd>
+          <h3 id="w3c-coordination">W3C Groups</h3>
+          <dl>
+            <dt>RDF Canonicalization and Hashing Working Group</dt>
+            <dd>
+              To synchronize on canonicalization output expression mechanisms that might be used by the VC Data
+              Integrity specification.
+            </dd>
 
-                <dt><a href="https://www.w3.org/2019/did-wg/">Decentralized Identifier Working Group</a></dt>
-                <dd>
-                    To synchronize on cryptography-related vocabularies and definitions.
-                </dd>
+            <dt><a href="https://www.w3.org/2019/did-wg/">Decentralized Identifier Working Group</a></dt>
+            <dd>
+              To synchronize on cryptography-related vocabularies and definitions.
+            </dd>
 
-                <dt><a href="https://www.w3.org/WoT/WG/">Web of Things Working Group</a></dt>
-                <dd>
-                    To synchronize on the needs and requirements of the WoT community, in particular on the subject of WoT Thing Descriptions, regarding digital signatures.
-                </dd>
+            <dt><a href="https://www.w3.org/WoT/WG/">Web of Things Working Group</a></dt>
+            <dd>
+              To synchronize on the needs and requirements of the WoT community, in particular on the subject of WoT
+              Thing Descriptions, regarding digital signatures.
+            </dd>
 
-                <dt><a href="https://w3c-ccg.github.io/">Credentials Community Group</a></dt>
-                <dd>
-                    Coordination on other specifications incubated by the Credentials Community Group that might utilize the output of this Working Group.
-                </dd>
-                <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architecture (APA) Working Group</a></dt>
-                <dd>
-                    Coordinate on accessibility use cases for verifiable credentials, and work jointly on a successor publication to inaccessible CAPTCHAs.
-                </dd>
-            </dl>
+            <dt><a href="https://w3c-ccg.github.io/">Credentials Community Group</a></dt>
+            <dd>
+              Coordination on other specifications incubated by the Credentials Community Group that might utilize the
+              output of this Working Group.
+            </dd>
+
+            <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architecture (APA) Working Group</a></dt>
+            <dd>
+              Coordinate on accessibility use cases for verifiable credentials, and work jointly on a successor
+              publication to inaccessible CAPTCHAs.
+            </dd>
+          </dl>
         </section>
 
         <section>
-            <h3 id="external-coordination">External Organizations</h3>
-            <dl>
-                <dt><a href="https://datatracker.ietf.org/">Internet Engineering Task Force</a> </dt>
-                <dd>
-                    The Working Group will seek security review from the IETF, coordinated through the Liaison.
-                </dd>
-                <dt><a href="https://datatracker.ietf.org/rg/cfrg/about/">Internet Engineering Task Force Crypto Forum Research Group </a> </dt>
-                <dd>
-                    To perform broad horizontal reviews on the output of the Working Group and to ensure that new pairing-based and post-quantum cryptographic algorithms and parameters can be integrated into the Data Integrity ecosystem.
-                </dd>
-                <dt><a href="https://www.nist.gov/"> National Institute of Standards and Technology, U.S. Department of Commerce </a></dt>
-                <dd>
-                    To coordinate in ensuring that new pairing-based and post-quantum cryptographic algorithms and parameters can be integrated into the Data Integrity ecosystem.
-                </dd>
-                <dt><a href="https://www.hyperledger.org/use/aries"> Hyperledger Aries</a></dt>
-                <dd>
-                    To coordinate on broad horizontal reviews and implementations related to the specifications developed by the Working Group.
-                </dd>
-                <dt><a href="https://www.aclu.org/">The American Civil Liberties Union</a> </dt>
-                <dd>
-                    To coordinate on ensuring that the deliverables of the Working Group are a net positive for civil liberties.
-                </dd>
-                <dt><a href="https://identity.foundation/interop/"> Decentralized Identity Foundation Interoperability Working Group </a> </dt>
-                <dd>
-                    To coordinate on broad horizontal review and integration of the specifications developed by the Working Group into the Decentralized Identity Foundation's ecosystem.
-                </dd>
-                <dt><a href="https://www.etsi.org/committee/esi">European Telecommunications Standards Institute - Electronic Signatures and Infrastructure Technical Committee</a> </dt>
-                <dd>
-                  To coordinate in ensuring that <a href="https://en.wikipedia.org/wiki/EIDAS">eIDAS</a>-compliant systems can be built on top of the specifications developed by the Working Group.
-                </dd>
-                <dt><a href="https://www.imsglobal.org/">IMS Global</a></dt>
-                <dd>
-                  Ensure that the badges being modeled and expressed by the Open Badges community are compatible with the Verifiable Credentials WG.
-                </dd>
-                <dt><a href="https://www.iso.org/committee/45144.html">ISO/IEC JTC 1/SC 17/WG 10</a><dt>
-                <dd>
-                  Ensure that the mobile driving licenses being modeled and expressed by the ISO SC17 WG10 community are compatible with the work of the Verifiable Credentials WG.
-                </dd>
-                <dt><a href="https://www.iso.org/committee/45144.html">ISO/IEC JTC 1/SC 17/WG 4</a><dt>
-                <dd>
-                  Ensure that the 23220-2 data model expressed by the ISO SC17 WG4 community is compatible with the work of the Verifiable Credentials WG.
-                </dd>
-            </dl>
+          <h3 id="external-coordination">External Organizations</h3>
+          <dl>
+            <dt><a href="https://datatracker.ietf.org/">Internet Engineering Task Force</a> </dt>
+            <dd>
+              The Working Group will seek security review from the IETF, coordinated through the Liaison.
+            </dd>
+            <dt><a href="https://datatracker.ietf.org/rg/cfrg/about/">Internet Engineering Task Force Crypto Forum
+                Research Group </a> </dt>
+            <dd>
+              To perform broad horizontal reviews on the output of the Working Group and to ensure that new
+              pairing-based and post-quantum cryptographic algorithms and parameters can be integrated into the Data
+              Integrity ecosystem.
+            </dd>
+            <dt><a href="https://www.nist.gov/"> National Institute of Standards and Technology, U.S. Department of
+                Commerce </a></dt>
+            <dd>
+              To coordinate in ensuring that new pairing-based and post-quantum cryptographic algorithms and parameters
+              can be integrated into the Data Integrity ecosystem.
+            </dd>
+            <dt><a href="https://www.hyperledger.org/use/aries"> Hyperledger Aries</a></dt>
+            <dd>
+              To coordinate on broad horizontal reviews and implementations related to the specifications developed by
+              the Working Group.
+            </dd>
+            <dt><a href="https://www.aclu.org/">The American Civil Liberties Union</a> </dt>
+            <dd>
+              To coordinate on ensuring that the deliverables of the Working Group are a net positive for civil
+              liberties.
+            </dd>
+            <dt><a href="https://identity.foundation/interop/"> Decentralized Identity Foundation Interoperability
+                Working Group </a> </dt>
+            <dd>
+              To coordinate on broad horizontal review and integration of the specifications developed by the Working
+              Group into the Decentralized Identity Foundation's ecosystem.
+            </dd>
+            <dt><a href="https://www.etsi.org/committee/esi">European Telecommunications Standards Institute -
+                Electronic Signatures and Infrastructure Technical Committee</a> </dt>
+            <dd>
+              To coordinate in ensuring that <a href="https://en.wikipedia.org/wiki/EIDAS">eIDAS</a>-compliant systems
+              can be built on top of the specifications developed by the Working Group.
+            </dd>
+            <dt><a href="https://www.imsglobal.org/">IMS Global</a></dt>
+            <dd>
+              Ensure that the badges being modeled and expressed by the Open Badges community are compatible with the
+              Verifiable Credentials WG.
+            </dd>
+            <dt><a href="https://www.iso.org/committee/45144.html">ISO/IEC JTC 1/SC 17/WG 10</a>
+            <dt>
+            <dd>
+              Ensure that the mobile driving licenses being modeled and expressed by the ISO SC17 WG10 community are
+              compatible with the work of the Verifiable Credentials WG.
+            </dd>
+            <dt><a href="https://www.iso.org/committee/45144.html">ISO/IEC JTC 1/SC 17/WG 4</a>
+            <dt>
+            <dd>
+              Ensure that the 23220-2 data model expressed by the ISO SC17 WG4 community is compatible with the work of
+              the Verifiable Credentials WG.
+            </dd>
+          </dl>
         </section>
       </section>
 
@@ -524,16 +751,23 @@
           Participation
         </h2>
         <p>
-          To be successful, this Working Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the Working Group. There is no minimum requirement for other Participants.
+          To be successful, this Working Group is expected to have 6 or more active participants for its duration,
+          including representatives from the key implementors of this specification, and active Editors and Test Leads
+          for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a
+          working day per week towards the Working Group. There is no minimum requirement for other Participants.
         </p>
         <p>
-          The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.
+          The group encourages questions, comments and issues on its public mailing lists and document repositories, as
+          described in <a href='#communication'>Communication</a>.
         </p>
         <p>
-          The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
+          The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement
+          to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
         </p>
-        <p>Participants in the group are required (by the <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>) to follow the
-          W3C <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.</p>
+        <p>
+          Participants in the group are required (by the <a
+            href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>) to follow the
+          W3C <a href="https://www.w3.org/Consortium/cepc/">Positive Work Environment at W3C: Code of Conduct</a>.</p>
       </section>
 
 
@@ -543,14 +777,22 @@
           Communication
         </h2>
         <p id="public">
-          Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed in public repositories and may permit direct public contribution requests.
-        The meetings themselves are not open to public participation, however.
+          Technical discussions for this Working Group are conducted in <a
+            href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from
+          teleconference and face-to-face meetings will be archived for public review, and technical discussions and
+          issue tracking will be conducted in a manner that can be both read and written to by the general public.
+          Working Drafts and Editor's Drafts of specifications will be developed in public repositories and may permit
+          direct public contribution requests.
+          The meetings themselves are not open to public participation, however.
         </p>
         <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="">Verifiable Credentials Working Group home page.</a>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and
+          meetings) will be available from the <a href="https://www.w3.org/2017/vc/WG/">Verifiable Credentials Working
+            Group home page.</a>
         </p>
         <p>
-          Most Verifiable Credentials Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+          Most Verifiable Credentials Working Group teleconferences will focus on discussion of particular
+          specifications, and will be conducted on an as-needed basis.
         </p>
         <p>
           This group primarily conducts its technical work on the public mailing list
@@ -561,11 +803,13 @@
           is invited to review, discuss and contribute to this work.
         </p>
         <p>
-          The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
+          The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the
+          Chairs and members of the group, for member-only discussions in special cases when a participant requests such
+          a discussion.
         </p>
         <p>
           The group will publish minutes for each teleconference on the
-          <a  href="https://www.w3.org/2017/vc/WG/Meetings/Minutes/">Group's home page</a>.
+          <a href="https://www.w3.org/2017/vc/WG/Meetings/Minutes/">Group's home page</a>.
         </p>
       </section>
 
@@ -576,54 +820,66 @@
           Decision Policy
         </h2>
         <p>
-          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 3.3</a>). Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+          This group will seek to make decisions through consensus and due process, per the <a
+            href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 5.2.1 Consensus)</a>.
+          Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with
+          members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
         <p>
-           However, if a decision is necessary for timely progress and consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote and record a decision along with any objections.
+          However, if a decision is necessary for timely progress and consensus is not achieved after careful
+          consideration of the range of views presented, the Chairs may call for a group vote and record a decision
+          along with any objections.
         </p>
         <p>
-          To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
+          To afford asynchronous decisions and organizational deliberation, any resolution (including publication
+          decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
 
-          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period of 1 week, depending on the chair's evaluation of the group consensus on the issue.
+          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or
+          web-based survey), with a response period of 1 week, depending on the chair's evaluation of the group
+          consensus on the issue.
 
-          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Working Group.
+          If no objections are raised by the end of the response period, the resolution will be considered to have
+          consensus as a resolution of the Working Group.
         </p>
         <p>
-          All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
+          All decisions made by the group should be considered resolved unless and until new information becomes
+          available or unless reopened at the discretion of the Chairs or the Director.
         </p>
         <p>
-          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C Process Document (Section 5.2.3, Deciding by Vote)</a> and includes no voting procedures beyond what the Process Document requires.
+          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C
+            Process Document (Section 5.2.3, Deciding by Vote)</a> and includes no voting procedures beyond what the
+          Process Document requires.
         </p>
       </section>
-
-
 
       <section id="patentpolicy">
         <h2>
           Patent Policy
         </h2>
         <p>
-          This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
+          This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent
+            Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to
+          issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
 
-          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C Patent Policy Implementation</a>.
+          For more information about disclosure obligations for this group, please see the <a
+            href="https://www.w3.org/groups/wg/vc/ipr/">W3C Patent Policy Implementation</a>.
         </p>
-
       </section>
-
-
 
       <section id="licensing">
         <h2>Licensing</h2>
-        <p>This Working Group will use the <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
+        <p>This Working Group will use the <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software
+            and Document license</a> for all its deliverables.</p>
       </section>
-
-
 
       <section id="about">
         <h2>
           About this Charter
         </h2>
         <p>
-          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section 3.4</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
+          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section
+            3.4</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a
+          conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall
+          take precedence.
         </p>
 
         <section id="history">
@@ -631,7 +887,9 @@
             Charter History
           </h3>
 
-          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 4.3, Advisory Committee Review of a Charter)</a>:</p>
+          <p>The following table lists details of all changes from the initial charter, per the <a
+              href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 4.3, Advisory
+              Committee Review of a Charter)</a>:</p>
 
 
           <table class="history">
@@ -662,11 +920,12 @@
                 <th>Update</th>
                 <td></td>
                 <td></td>
-	              <td>2018-09-12 (coralie): Updated Chairs</td>
+                <td>2018-09-12 (coralie): Updated Chairs</td>
               </tr>
 
               <tr>
-                <th><a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2019JanMar/0051.html">Charter Extension</a></th>
+                <th><a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2019JanMar/0051.html">Charter
+                    Extension</a></th>
                 <td>1 April 2019</td>
                 <td>30 September 2019</td>
                 <td>2019-03-29 (kaz): Charter period extended till 30 September 2019</td>
@@ -711,7 +970,9 @@
 
                 </td>
                 <td>
-                  <p>2020-06-15 (ivan): <a href='https://lists.w3.org/Archives/Member/w3c-ac-members/2020AprJun/0053.html'>Removed Matt Stone as a co-chair</a>.</p>
+                  <p>2020-06-15 (ivan): <a
+                      href='https://lists.w3.org/Archives/Member/w3c-ac-members/2020AprJun/0053.html'>Removed Matt Stone
+                      as a co-chair</a>.</p>
                 </td>
               </tr>
               <tr>
@@ -719,7 +980,8 @@
                 <td></td>
                 <td></td>
                 <td>
-                  <p><a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2020JulSep/0013.html">2020-07-24</a> (xueyuan): Daniel Burnett re-appointed as group Chair.</p>
+                  <p><a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2020JulSep/0013.html">2020-07-24</a>
+                    (xueyuan): Daniel Burnett re-appointed as group Chair.</p>
                 </td>
               </tr>
               <tr>
@@ -729,7 +991,8 @@
                 <td>New Patent Policy</td>
               </tr>
               <tr>
-                <th><a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2021OctDec/0052.html">Charter Extension</a></th>
+                <th><a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2021OctDec/0052.html">Charter
+                    Extension</a></th>
                 <td>30 December 2021</td>
                 <td>30 April 2022</td>
                 <td>2021-12-20: Charter extended till 30 April 2022</td>
@@ -745,8 +1008,12 @@
                   05 May 2022
                 </td>
                 <td>
-                  2021-12-20 (Ivan): Proposed work on an update of the VC Data model, and a new deliverable on VC Data Integrity. See the
-                  <a href="https://lists.w3.org/Archives/Public/public-new-work/2021Dec/0008.html">Advanced Notice</a>, and the <a href="https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githack.com%2Fw3c%2Fvc-wg-charter%2Fe309d2a94beca018b2bc75bbaf4b7f3f8f212705%2Findex.html&doc2=https%3A%2F%2Fw3c.github.io%2Fvc-wg-charter%2F">changes on the proposed charter</a> in the advanced notice period.
+                  2021-12-20 (Ivan): Proposed work on an update of the VC Data model, and a new deliverable on VC Data
+                  Integrity. See the
+                  <a href="https://lists.w3.org/Archives/Public/public-new-work/2021Dec/0008.html">Advanced Notice</a>,
+                  and the <a
+                    href="https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githack.com%2Fw3c%2Fvc-wg-charter%2Fe309d2a94beca018b2bc75bbaf4b7f3f8f212705%2Findex.html&doc2=https%3A%2F%2Fw3c.github.io%2Fvc-wg-charter%2F">changes
+                    on the proposed charter</a> in the advanced notice period.
                 </td>
               </tr>
               <tr>
@@ -765,7 +1032,8 @@
               </tr>
               <tr>
                 <th>
-                  Work starts with <a href="https://www.w3.org/2022/06/verifiable-credentials-wg-charter.html">new charter</a>
+                  Work starts with <a href="https://www.w3.org/2022/06/verifiable-credentials-wg-charter.html">new
+                    charter</a>
                 </th>
                 <td>
                   13 June 2022
@@ -774,7 +1042,8 @@
                   15 June 2024
                 </td>
                 <td>
-                  2022-06-13 (Ivan): AC Vote ends, WG is not in maintenance mode any more; Kristina Yasuda replaces Wayne Chang as co-chair.
+                  2022-06-13 (Ivan): AC Vote ends, WG is not in maintenance mode any more; Kristina Yasuda replaces
+                  Wayne Chang as co-chair.
                 </td>
               </tr>
               <tr>
@@ -802,26 +1071,39 @@
                   15 June 2024
                 </td>
                 <td>
-                  2023-10-31 (Xueyuan): Brent Zundel is re-appointed and Kristina Yasuda steps down as co-chair of the group.
+                  2023-10-31 (Xueyuan): Brent Zundel is re-appointed and Kristina Yasuda steps down as co-chair of the
+                  group.
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  Working on a charter extension
+                </th>
+                <td>
+                  March 2024
+                </td>
+                <td>
+                </td>
+                <td>
                 </td>
               </tr>
             </tbody>
           </table>
         </section>
 
-<!--
+        <!--
         <section id="changelog">
           <h3>Change log</h3>
           <!-- Use this section for changes _after_ the charter was approved by the Director. -->
-<!--          <p>Changes to this document are documented in this section.</p>
+        <!--          <p>Changes to this document are documented in this section.</p>
 -->
-          <!--
+        <!--
           <dl id='changes'>
             <dt>YYYY-MM-DD</dt>
             <dd>[changes]]</dd>
           </dl>
           -->
-<!--        </section>
+        <!--        </section>
       </section>
 -->
     </main>
@@ -836,12 +1118,15 @@
       <p class="copyright">
         <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©2024
         <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>.
-
-        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
+        <abbr title="World Wide Web Consortium">W3C</abbr> <a
+          href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a
+          href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a
+          href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
       </p>
       <hr>
       <p><a href="https://github.com/w3c/vc-wg-charter">Yes, it's on GitHub!</a>.</p>
     </footer>
 
   </body>
+
 </html>


### PR DESCRIPTION
Per advice of PlH, this is a full-blown charter proposal for the coming two years, instead of just asking for a 6 months extension. The "real" changes are minimal: the scope (and out-of-scope) sections did not change _except_ for the statement whereby the WG will convert into a maintenance WG once all Recommendations are published (with an expected date set now to January '25).

The bulk of the change is administrative: the charter lists the current situation for all our rec-track documents.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/pull/112.html" title="Last updated on Mar 20, 2024, 2:58 PM UTC (2253408)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/112/99dcede...2253408.html" title="Last updated on Mar 20, 2024, 2:58 PM UTC (2253408)">Diff</a>