### PR TITLE
Added the reference to the controller document

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
         <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/98922/join">Join the Verifiable Credentials Working Group.</a></p>
       </div>
 
-
+      <!-- MARK: Overall Header -->
       <section id="details">
         <table class="summary-table">
           <tr id="Status">
@@ -143,6 +143,7 @@
         </table>
       </section>
 
+      <!-- MARK: Scope -->
       <section id="scope" class="scope">
         <h2>Scope</h2>
         <p>
@@ -185,6 +186,7 @@
 
       </section>
 
+      <!-- MARK: Deliverables -->
       <section id="deliverables">
         <h2>
           Deliverables
@@ -619,6 +621,7 @@
         </section>
       </section>
 
+      <!-- MARK: Success Criteria -->
       <section id="success-criteria">
         <h2>Success Criteria</h2>
 
@@ -648,6 +651,7 @@
         </p>
       </section>
 
+      <!-- MARK: Coordination -->
       <section id="coordination">
         <h2>Coordination</h2>
         <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for
@@ -740,6 +744,7 @@
 
 
 
+      <!-- MARK: Participation -->
       <section class="participation">
         <h2 id="participation">
           Participation
@@ -758,7 +763,7 @@
       </section>
 
 
-
+      <!-- MARK: Communication -->
       <section id="communication">
         <h2>
           Communication
@@ -791,7 +796,7 @@
       </section>
 
 
-
+      <!-- MARK: Decision Policy -->
       <section id="decisions">
         <h2>
           Decision Policy
@@ -817,7 +822,7 @@
       </section>
 
 
-
+      <!-- MARK: Patent Policy -->
       <section id="patentpolicy">
         <h2>
           Patent Policy
@@ -831,13 +836,11 @@
       </section>
 
 
-
+      <!-- MARK: Licensing -->
       <section id="licensing">
         <h2>Licensing</h2>
         <p>This Working Group will use the <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
       </section>
-
-
 
       <section id="about">
         <h2>
@@ -847,6 +850,7 @@
           This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section 3.4</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
         </p>
 
+        <!-- MARK: Charter History -->
         <section id="history">
           <h3>
             Charter History

--- a/index.html
+++ b/index.html
@@ -444,6 +444,45 @@
                   Public Working Draft)</a>
                 Exclusion period <b>began</b> 2023-04-27; Exclusion period <b>ended</b> 2023-09-24.
               </p>
+              <p class="todo">
+                There is an open <a href="https://github.com/w3c/strategy/issues/455">CR Transition request</a> for this document. At
+                the time of publishing the new charter, if accepted, the data in the previous paragraph will be updated 
+                accordingly.
+              </p>
+              <p>
+                <b>Exclusion Draft Charter:</b> https://www.w3.org/2022/06/verifiable-credentials-wg-charter.html</b>
+              </p>
+            </dd>
+          </dl>
+
+          <dl>
+            <dt id="controller" class="spec">Controller Documents 1.0</dt>
+            <dd>
+              <p>
+                A controller document is a set of data that specifies one or more relationships between a controller and a set of data,
+                such as a set of public cryptographic keys.
+              </p>
+          
+              <p class="draft-status"> <b>Draft state:</b> <a href="https://www.w3.org/TR/2024/WD-controller-document-20240514/">Working
+                  Draft</a></p>
+          
+              <p class="milestone"><b>Expected completion:</b> 2025-01-31</p>
+          
+              <p>
+                <b>Adopted Draft:</b> <a href='https://www.w3.org/TR/controller-document/'>Controller Documents v1.0</a>
+              </p>
+          
+              <p class="todo">
+                <b>Exclusion Draft:</b>
+                <a href='https://www.w3.org/TR/2024/WD-controller-document-20240514/'>https://www.w3.org/TR/2024/WD-controller-document-20240514/ (First
+                  Public Working Draft)</a>
+                Exclusion period <span class="todo">TBD.</span>.
+              </p>
+              <p class="todo">
+                There is an open <a href="https://github.com/w3c/transitions/issues/610">FPWD Transition request</a> for this document. At
+                the time of publishing the new charter, if accepted, the data in the previous paragraph will be updated
+                accordingly.
+              </p>
               <p>
                 <b>Exclusion Draft Charter:</b> https://www.w3.org/2022/06/verifiable-credentials-wg-charter.html</b>
               </p>


### PR DESCRIPTION
Two changes:

- Added a reference to the controller document, with (at this moment) temporary data. Should be updated to the final data (FPWD reference and corresponding exclusion draft reference) at least by the time the charter comes into effect.
- Added a to-do note for the bitstring document, to update to the CR reference and the corresponding exclusion draft reference at least by the time the charter comes into effect.

This should fix #115.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/pull/117.html" title="Last updated on May 13, 2024, 9:12 AM UTC (651c988)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/117/162051f...651c988.html" title="Last updated on May 13, 2024, 9:12 AM UTC (651c988)">Diff</a>