### PR TITLE
Added the introduction of BBS into the history table

### DIFF
--- a/index.html
+++ b/index.html
@@ -1021,6 +1021,19 @@
               </tr>
               <tr>
                 <th>
+                  <a href="https://www.w3.org/TR/2023/WD-vc-di-bbs-20230518/">"BBS Cryptosuite"</a> becomes officially a normative specification deliverable
+                </th>
+                <td>
+                  18 May 2023
+                </td>
+                <td>
+                </td>
+                <td>
+                  The document has fulfilled the criteria for <a href="#conditional-normative">conditional normative specification</a> to be added to the official deliverables of the Working Group.
+                </td>
+              </tr>
+              <tr>
+                <th>
                   Update
                 </th>
                 <td>


### PR DESCRIPTION
This is to (partially) answer https://github.com/w3c/strategy/issues/455#issuecomment-2176646271: adding the fact of BBS becoming an official deliverable into the history table.

cc @himorin


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/pull/120.html" title="Last updated on Jun 23, 2024, 7:09 AM UTC (f33eb87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-wg-charter/120/76a0f04...f33eb87.html" title="Last updated on Jun 23, 2024, 7:09 AM UTC (f33eb87)">Diff</a>